### PR TITLE
Processamento por N tabelas e show columns opcional

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 
 This connector is used to write data to snowflake. It is a sink connector that reads data from Kafka topics and writes it to snowflake tables.
 
+### MERGE deduplication via HASH
+
+When flushing buffered records into the final Snowflake table, the connector uses a `MERGE` statement with a **HASH-based guard** on the `WHEN MATCHED` clause:
+
+```sql
+WHEN MATCHED AND HASH(final.col1, final.col2, ...) <> HASH(ingest.col1, ingest.col2, ...) THEN UPDATE SET ...
+```
+
+This prevents Snowflake from writing a new micro-partition when a full-load re-publish sends records that are **identical** to what is already stored. The `UPDATE` only executes when the hash of the incoming row differs from the hash of the existing row, eliminating unnecessary DML and the micro-partition fragmentation it causes.
+
+This behaviour covers all columns present in the final table (`columnsFinalTable`), including both PK and non-PK fields.

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.10.0-rc.6</version>
+  <version>3.10.0-rc.7</version>
   <build>
     <plugins>
       <plugin>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.10.0-rc.3</version>
+  <version>3.10.0-rc.4</version>
   <build>
     <plugins>
       <plugin>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.10.0-rc.2</version>
+  <version>3.10.0-rc.3</version>
   <build>
     <plugins>
       <plugin>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.10.0-rc.1</version>
+  <version>3.10.0-rc.2</version>
   <build>
     <plugins>
       <plugin>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.10.0-rc.7</version>
+  <version>3.10.0-rc.8</version>
   <build>
     <plugins>
       <plugin>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.10.0-rc.4</version>
+  <version>3.10.0-rc.5</version>
   <build>
     <plugins>
       <plugin>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.10.0-rc.5</version>
+  <version>3.10.0-rc.6</version>
   <build>
     <plugins>
       <plugin>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>br.com.datastreambrasil</groupId>
   <artifactId>snowflake-sink-connector</artifactId>
-  <version>3.9.6</version>
+  <version>3.10.0-rc.1</version>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.10.0-rc.2</version>
+    <version>3.10.0-rc.3</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.10.0-rc.4</version>
+    <version>3.10.0-rc.5</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.10.0-rc.6</version>
+    <version>3.10.0-rc.7</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.10.0-rc.5</version>
+    <version>3.10.0-rc.6</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.9.6</version>
+    <version>3.10.0-rc.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.10.0-rc.3</version>
+    <version>3.10.0-rc.4</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.10.0-rc.7</version>
+    <version>3.10.0-rc.8</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>br.com.datastreambrasil</groupId>
     <artifactId>snowflake-sink-connector</artifactId>
-    <version>3.10.0-rc.1</version>
+    <version>3.10.0-rc.2</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkConnector.java
+++ b/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkConnector.java
@@ -26,6 +26,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
     protected static final String CFG_PAYLOAD_CDC_FORMAT = "payload_cdc_format";
     protected static final String CFG_IGNORE_COLUMNS = "ignore_columns";
     protected static final String FIND_COLUMNS_IN_METADATA = "find_columns_in_metadata";
+    protected static final String CFG_TABLE_FIELDS = "table_fields";
 
     /*
      * For some use cases we need to load all data again, each time. So we have two
@@ -83,7 +84,10 @@ public class SnowflakeSinkConnector extends SinkConnector {
                     "If we don't receive any event for this amount of time, we will truncate the table in snowflake")
             .define(FIND_COLUMNS_IN_METADATA, ConfigDef.Type.BOOLEAN, Boolean.FALSE,
                     ConfigDef.Importance.HIGH,
-                    "Define whether to retrieve column names from the metadata or by querying the information schema.");
+                    "Define whether to retrieve column names from the metadata or by querying the information schema.")
+            .define(CFG_TABLE_FIELDS, ConfigDef.Type.LIST, List.of(),
+                    ConfigDef.Importance.HIGH,
+                    "Defines the names of the fields of table to be processed.");
 
     private Map<String, String> props;
 

--- a/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkTask.java
+++ b/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkTask.java
@@ -149,11 +149,12 @@ public class SnowflakeSinkTask extends SinkTask {
             properties.put(CLIENT_METADATA_USE_SESSION_DATABASE, "true");
             properties.put(CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX, "true");
 
-            // Desabilita Arrow, usa JSON como formato de resultado
-            // Resolve ExceptionInInitializerError com sun.misc.Unsafe no Java 17+
-            // Ref: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure
-            properties.put(JDBC_QUERY_RESULT_FORMAT, "JSON");
-
+            if (!config.getBoolean(SnowflakeSinkConnector.FIND_COLUMNS_IN_METADATA)) {
+                // Desabilita Arrow, usa JSON como formato de resultado
+                // Resolve ExceptionInInitializerError com sun.misc.Unsafe no Java 17+
+                // Ref: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure
+                properties.put(JDBC_QUERY_RESULT_FORMAT, "JSON");
+            }
             connection = DriverManager.getConnection(map.get(SnowflakeSinkConnector.CFG_URL), properties);
             snowflakeConnection = connection.unwrap(SnowflakeConnection.class);
 

--- a/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkTask.java
+++ b/src/main/java/br/com/datastreambrasil/v2/SnowflakeSinkTask.java
@@ -159,7 +159,10 @@ public class SnowflakeSinkTask extends SinkTask {
             snowflakeConnection = connection.unwrap(SnowflakeConnection.class);
 
             //fill columns
-            if (config.getBoolean(SnowflakeSinkConnector.FIND_COLUMNS_IN_METADATA)) {
+            if (!config.getList(SnowflakeSinkConnector.CFG_TABLE_FIELDS).isEmpty()) {
+                columnsFinalTable = getColumnsFromConfig(config.getList(SnowflakeSinkConnector.CFG_TABLE_FIELDS));
+            }
+            else if (config.getBoolean(SnowflakeSinkConnector.FIND_COLUMNS_IN_METADATA)) {
                 columnsFinalTable = getColumnsFromMetadata(tableName);
             } else {
                 columnsFinalTable = getColumnsFromMetadataInformationSchema(tableName);
@@ -195,6 +198,11 @@ public class SnowflakeSinkTask extends SinkTask {
             LOGGER.error("Error while starting Snowflake connector", e);
             throw new RuntimeException("Error while starting Snowflake connector", e);
         }
+    }
+
+    private List<String> getColumnsFromConfig(List<String> fields) {
+        fields.removeAll(ignoreColumns);
+        return  fields;
     }
 
     @Override

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -46,6 +46,7 @@ public abstract class AbstractProcessor {
     protected boolean processMultiTables;
     protected boolean findInColumnsMetadata;
     protected boolean mustProcessReadOnlyMessages;
+    protected boolean copyOnly = false;
 
     protected static final String AFTER = "after";
     protected static final String BEFORE = "before";
@@ -123,6 +124,7 @@ public abstract class AbstractProcessor {
         processMultiTables = config.getBoolean(SnowflakeSinkConnector.CFG_PROCESS_MULTIPLE_TABLES);
         findInColumnsMetadata = config.getBoolean(SnowflakeSinkConnector.CFG_FIND_COLUMNS_IN_METADATA);
         mustProcessReadOnlyMessages = config.getBoolean(SnowflakeSinkConnector.CFG_MUST_PROCESS_READ_ONLY_MESSAGES);
+        copyOnly = config.getBoolean(SnowflakeSinkConnector.COPY_ONLY);
     }
 
     protected void setupSnowflakeConnection(AbstractConfig config) {

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -156,7 +156,7 @@ public abstract class AbstractProcessor {
      * Falls back to the configured tableName when the topic has no dot separator.
      */
     protected String extractTableNameFromTopic(String topic) {
-        if (topic != null && topic.contains(".")) {
+        if (topic != null && topic.contains(".") && processMultiTables) {
             return topic.substring(topic.lastIndexOf(".") + 1);
         }
         return tableName;

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -95,7 +95,10 @@ public abstract class AbstractProcessor {
         configParameters(config);
         setupSnowflakeConnection(config);
 
-        if (findInColumnsMetadata && !processMultiTables) {
+        var tablesFields = config.getString(SnowflakeSinkConnector.CFG_TABLES_FIELDS);
+        if (tablesFields != null && !tablesFields.isBlank()) {
+            loadColumnsFromConfig(tablesFields);
+        } else if (findInColumnsMetadata && !processMultiTables) {
             prepareColumnsFromMetadata(tableName.toUpperCase(), config);
         } else {
             preloadAllTableColumns();
@@ -199,6 +202,40 @@ public abstract class AbstractProcessor {
         LOGGER.info("Pre-loaded columns for {} ingest tables in schema {}", rawByIngestTable.size(), schemaName);
     }
 
+    void loadColumnsFromConfig(String tablesFields) {
+        var tableEntries = tablesFields.split("\\|");
+
+        for (var entry : tableEntries) {
+            var dashIdx = entry.indexOf('-');
+            if (dashIdx <= 0) {
+                throw new RuntimeException(
+                    "Invalid tables_fields format, expected 'tableName-field1,field2': " + entry);
+            }
+
+            var baseTableName = entry.substring(0, dashIdx).trim().toUpperCase();
+            var fieldsString = entry.substring(dashIdx + 1).trim();
+            var rawCols = new ArrayList<>(List.of(fieldsString.split(",")));
+            rawCols.replaceAll(String::trim);
+
+            rawCols.removeAll(ignoreColumns);
+
+            List<String> ingestCols = new ArrayList<>(rawCols);
+            ingestCols.addAll(excludeIngestAdditionalFields);
+
+            var ingestTableName = baseTableName + INGEST_SUFFIX;
+            columnsIngestTable.put(ingestTableName, ingestCols);
+            columnsFinalTable.put(baseTableName, rawCols);
+            knownIngestTables.add(ingestTableName);
+
+            LOGGER.debug("Loaded {} columns from config for ingest table: {} - Columns names: {}",
+                    rawCols.size(), ingestTableName, ingestCols);
+            LOGGER.debug("Loaded {} columns from config for ingest table: {} for final table: {} - Columns names: {}",
+                    ingestCols.size(), ingestTableName, baseTableName, rawCols);
+        }
+
+        LOGGER.info("Loaded columns for {} tables from config", tableEntries.length);
+    }
+
     protected CompressedMap<SnowflakeRecord> getOrCreateBuffer(String tableBaseName) {
         return buffer.computeIfAbsent(tableBaseName, k -> {
             knownIngestTables.add(String.format("%s%s", tableBaseName, INGEST_SUFFIX));
@@ -223,14 +260,12 @@ public abstract class AbstractProcessor {
             }
 
             columnsFromTable.removeAll(ignoreColumns);
-            var columnsNoDuplicate = columnsFromTable.stream().distinct().toList();
 
             LOGGER.debug("Columns: {} mapped from target table: {}",
-                    String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate), table);
+                    String.join(LINE_SEPARATOR_COMMA, columnsFromTable), table);
 
             var ingestTableName = String.format("%s%s", table, INGEST_SUFFIX);
-            var columnsFromIngestTable = new ArrayList<String>();
-            columnsFromIngestTable.addAll(columnsFromTable);
+            var columnsFromIngestTable = new ArrayList<>(columnsFromTable);
             columnsFromIngestTable.addAll(config.getList(SnowflakeSinkConnector.CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS));
 
             columnsIngestTable.put(ingestTableName, columnsFromIngestTable);

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -45,6 +45,7 @@ public abstract class AbstractProcessor {
     protected String tmpDataFolder;
     protected boolean processMultiTables;
     protected boolean findInColumnsMetadata;
+    protected boolean mustProcessReadOnlyMessages;
 
     protected static final String AFTER = "after";
     protected static final String BEFORE = "before";
@@ -120,6 +121,7 @@ public abstract class AbstractProcessor {
         bufferInitialCapacity = config.getInt(SnowflakeSinkConnector.CFG_BUFFER_INITIAL_CAPACITY);
         processMultiTables = config.getBoolean(SnowflakeSinkConnector.CFG_PROCESS_MULTIPLE_TABLES);
         findInColumnsMetadata = config.getBoolean(SnowflakeSinkConnector.CFG_FIND_COLUMNS_IN_METADATA);
+        mustProcessReadOnlyMessages = config.getBoolean(SnowflakeSinkConnector.CFG_MUST_PROCESS_READ_ONLY_MESSAGES);
     }
 
     protected void setupSnowflakeConnection(AbstractConfig config) {

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -191,7 +191,6 @@ public abstract class AbstractProcessor {
 
             columnsIngestTable.put(ingestTableName, ingestCols);
             columnsFinalTable.put(baseTableName, finalCols);
-            knownIngestTables.add(ingestTableName);
 
             LOGGER.debug("Pre-loaded {} columns for ingest table: {} - Columns names: {}",
                     ingestCols.size(), ingestTableName, ingestCols);

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -35,6 +35,7 @@ public abstract class AbstractProcessor {
     protected Map<String, List<String>> columnsFinalTable = new HashMap<>();
     protected Map<String, List<String>> columnsIngestTable = new HashMap<>();
     protected List<String> ignoreColumns = new ArrayList<>();
+    protected List<String> excludeIngestAdditionalFields = new ArrayList<>();
     protected List<String> timestampFieldsConvert = new ArrayList<>();
     protected List<String> dateFieldsConvert = new ArrayList<>();
     protected List<String> timeFieldsConvert = new ArrayList<>();
@@ -94,6 +95,7 @@ public abstract class AbstractProcessor {
         dateFieldsConvert.addAll(config.getList(SnowflakeSinkConnector.CFG_DATE_FIELDS_CONVERT));
         timeFieldsConvert.addAll(config.getList(SnowflakeSinkConnector.CFG_TIME_FIELDS_CONVERT));
         ignoreColumns.addAll(config.getList(SnowflakeSinkConnector.CFG_IGNORE_COLUMNS));
+        excludeIngestAdditionalFields.addAll(config.getList(SnowflakeSinkConnector.CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS));
 
         tmpDataFolder = config.getString(SnowflakeSinkConnector.CFG_TMP_DATA_FOLDER);
         bufferInitialCapacity = config.getInt(SnowflakeSinkConnector.CFG_BUFFER_INITIAL_CAPACITY);
@@ -139,8 +141,13 @@ public abstract class AbstractProcessor {
         }
         try {
             String ingestTable = tableBaseName + INGEST_SUFFIX;
-            columnsIngestTable.put(tableBaseName, getColumnsFromMetadata(ingestTable));
-            columnsFinalTable.put(tableBaseName, getColumnsFromMetadata(tableBaseName));
+            List<String> ingestCols = getColumnsFromMetadata(ingestTable);
+            List<String> finalCols = ingestCols.stream()
+                    .filter(col -> excludeIngestAdditionalFields.stream()
+                            .noneMatch(excluded -> excluded.equalsIgnoreCase(col)))
+                    .toList();
+            columnsIngestTable.put(tableBaseName, ingestCols);
+            columnsFinalTable.put(tableBaseName, finalCols);
         } catch (SQLException e) {
             LOGGER.error("Error while loading metadata columns for table {}", tableBaseName, e);
             throw new RuntimeException("Error while loading metadata columns for table " + tableBaseName, e);

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -82,6 +82,12 @@ public abstract class AbstractProcessor {
         ORDER BY ORDINAL_POSITION
         """;
 
+    private static final String FIND_ALL_INGEST_TABLE_COLUMNS = """
+        SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME LIKE '%%_INGEST'
+        ORDER BY TABLE_NAME, ORDINAL_POSITION
+        """;
+
     protected abstract void extraConfigsOnStart(AbstractConfig config);
 
     protected abstract void put(Collection<SinkRecord> collection);
@@ -93,6 +99,9 @@ public abstract class AbstractProcessor {
     protected void start(AbstractConfig config) {
         configParameters(config);
         setupSnowflakeConnection(config);
+        if (processMultiTables) {
+            preloadAllIngestTableColumns();
+        }
         extraConfigsOnStart(config);
     }
 
@@ -156,12 +165,12 @@ public abstract class AbstractProcessor {
      * No-op if columns for the table are already cached.
      */
     protected void ensureColumnsForTable(String tableBaseName) {
-        if (columnsIngestTable.containsKey(tableBaseName)) {
+        if (columnsIngestTable.containsKey(tableBaseName.toUpperCase())) {
             return;
         }
 
         try {
-            String ingestTable = String.format("%s%s", tableBaseName, INGEST_SUFFIX);
+            String ingestTable = tableBaseName + INGEST_SUFFIX;
             List<String> ingestCols = findInColumnsMetadata
                     ? getColumnsFromMetadata(ingestTable)
                     : getColumnsFromMetadataInformationSchema(ingestTable);
@@ -171,12 +180,52 @@ public abstract class AbstractProcessor {
                             .noneMatch(excluded -> excluded.equalsIgnoreCase(col)))
                     .toList();
 
-            columnsIngestTable.put(tableBaseName, ingestCols);
-            columnsFinalTable.put(tableBaseName, finalCols);
+            columnsIngestTable.put(tableBaseName.toUpperCase(), ingestCols);
+            columnsFinalTable.put(tableBaseName.toUpperCase(), finalCols);
         } catch (SQLException e) {
             LOGGER.error("Error while loading metadata columns for table {}", tableBaseName, e);
             throw new RuntimeException("Error while loading metadata columns for table " + tableBaseName, e);
         }
+    }
+
+    // Package-private for testability
+    void preloadAllIngestTableColumns() {
+        String sql = String.format(FIND_ALL_INGEST_TABLE_COLUMNS, schemaName.toUpperCase());
+        Map<String, List<String>> rawByIngestTable = new HashMap<>();
+
+        try (var stmt = connection.createStatement(); var rs = stmt.executeQuery(sql)) {
+            while (rs.next()) {
+                rawByIngestTable
+                        .computeIfAbsent(rs.getString("TABLE_NAME"), k -> new ArrayList<>())
+                        .add(rs.getString("COLUMN_NAME"));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error pre-loading ingest table columns for schema " + schemaName, e);
+        }
+
+        if (rawByIngestTable.isEmpty()) {
+            LOGGER.warn("No _INGEST tables found in schema {} during pre-load", schemaName);
+            return;
+        }
+
+        for (var entry : rawByIngestTable.entrySet()) {
+            String ingestTableName = entry.getKey();
+            String baseTableName = ingestTableName.substring(0, ingestTableName.length() - INGEST_SUFFIX.length());
+
+            List<String> ingestCols = new ArrayList<>(entry.getValue());
+            ingestCols.removeAll(ignoreColumns);
+
+            List<String> finalCols = ingestCols.stream()
+                    .filter(col -> excludeIngestAdditionalFields.stream()
+                            .noneMatch(excluded -> excluded.equalsIgnoreCase(col)))
+                    .toList();
+
+            columnsIngestTable.put(baseTableName, ingestCols);
+            columnsFinalTable.put(baseTableName, finalCols);
+            LOGGER.debug("Pre-loaded {} columns for table: {}", ingestCols.size(), baseTableName);
+        }
+
+        LOGGER.info("Pre-loaded columns for {} ingest tables in schema {}", rawByIngestTable.size(), schemaName);
     }
 
     protected CompressedMap<SnowflakeRecord> getOrCreateBuffer(String tableBaseName) {

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -96,7 +96,7 @@ public abstract class AbstractProcessor {
         setupSnowflakeConnection(config);
 
         if (findInColumnsMetadata && !processMultiTables) {
-            prepareColumnsFromMetadata(tableName, config);
+            prepareColumnsFromMetadata(tableName.toUpperCase(), config);
         } else {
             preloadAllTableColumns();
         }
@@ -138,7 +138,7 @@ public abstract class AbstractProcessor {
                 // Resolve ExceptionInInitializerError com sun.misc.Unsafe no Java 17+
                 // Ref: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure
                 properties.put(JDBC_QUERY_RESULT_FORMAT, "JSON");
-                LOGGER.warn("Find columns by information_schema query to schema: {}", schemaName);
+                LOGGER.warn("Find columns by information_schema.columns query to schema: {}", schemaName);
             }
 
             connection = DriverManager.getConnection(config.getString(SnowflakeSinkConnector.CFG_URL), properties);
@@ -206,16 +206,17 @@ public abstract class AbstractProcessor {
         });
     }
 
-    protected void prepareColumnsFromMetadata(String table, AbstractConfig config) {
+    void prepareColumnsFromMetadata(String table, AbstractConfig config) {
         try {
             var metadata = connection.getMetaData();
 
             var columnsFromTable = new ArrayList<String>();
-            try (var rsColumns = metadata.getColumns(null, schemaName.toUpperCase(), table.toUpperCase(), null)) {
+            try (var rsColumns = metadata.getColumns(null, schemaName.toUpperCase(), table, null)) {
                 while (rsColumns.next()) {
                     columnsFromTable.add(rsColumns.getString("COLUMN_NAME"));
                 }
             }
+
             if (columnsFromTable.isEmpty()) {
                 throw new RuntimeException(
                     "Empty columns returned from target table " + table + ", schema " + schemaName);
@@ -224,7 +225,8 @@ public abstract class AbstractProcessor {
             columnsFromTable.removeAll(ignoreColumns);
             var columnsNoDuplicate = columnsFromTable.stream().distinct().toList();
 
-            LOGGER.debug("Columns: {} mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate), table);
+            LOGGER.debug("Columns: {} mapped from target table: {}",
+                    String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate), table);
 
             var ingestTableName = String.format("%s%s", table, INGEST_SUFFIX);
             var columnsFromIngestTable = new ArrayList<String>();

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -77,12 +77,6 @@ public abstract class AbstractProcessor {
     private static final String CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX = "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX";
     private static final String JDBC_QUERY_RESULT_FORMAT = "JDBC_QUERY_RESULT_FORMAT";
 
-    private static final String FIND_COLUMNS = """
-        SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'
-        ORDER BY ORDINAL_POSITION
-        """;
-
     private static final String FIND_ALL_INGEST_TABLE_COLUMNS = """
         SELECT TABLE_NAME, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
         WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME LIKE '%%_INGEST'
@@ -101,10 +95,10 @@ public abstract class AbstractProcessor {
         configParameters(config);
         setupSnowflakeConnection(config);
 
-        if (processMultiTables) {
-            preloadAllTableColumns();
+        if (findInColumnsMetadata && !processMultiTables) {
+            prepareColumnsFromMetadata(tableName, config);
         } else {
-            knownIngestTables.add(String.format("%s%s", tableName, INGEST_SUFFIX));
+            preloadAllTableColumns();
         }
 
         extraConfigsOnStart(config);
@@ -162,7 +156,6 @@ public abstract class AbstractProcessor {
         return tableName;
     }
 
-    // Package-private for testability
     void preloadAllTableColumns() {
         String sql = String.format(FIND_ALL_INGEST_TABLE_COLUMNS, schemaName.toUpperCase());
         Map<String, List<String>> rawByIngestTable = new HashMap<>();
@@ -213,46 +206,36 @@ public abstract class AbstractProcessor {
         });
     }
 
-    protected List<String> getColumnsFromMetadata(String table) throws SQLException {
-        var metadata = connection.getMetaData();
+    protected void prepareColumnsFromMetadata(String table, AbstractConfig config) {
+        try {
+            var metadata = connection.getMetaData();
 
-        var columnsFromTable = new ArrayList<String>();
-        try (var rsColumns = metadata.getColumns(null, schemaName.toUpperCase(), table.toUpperCase(), null)) {
-            while (rsColumns.next()) {
-                columnsFromTable.add(rsColumns.getString("COLUMN_NAME"));
+            var columnsFromTable = new ArrayList<String>();
+            try (var rsColumns = metadata.getColumns(null, schemaName.toUpperCase(), table.toUpperCase(), null)) {
+                while (rsColumns.next()) {
+                    columnsFromTable.add(rsColumns.getString("COLUMN_NAME"));
+                }
             }
-        }
-        if (columnsFromTable.isEmpty()) {
-            throw new RuntimeException(
-                "Empty columns returned from target table " + table + ", schema " + schemaName);
-        }
-
-        columnsFromTable.removeAll(ignoreColumns);
-        var columnsNoDuplicate = columnsFromTable.stream().distinct().toList();
-
-        LOGGER.debug("Columns: {} mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate), table);
-
-        return columnsNoDuplicate;
-    }
-
-    private List<String> getColumnsFromMetadataInformationSchema(String table) throws SQLException {
-        var columnsFromTable = new ArrayList<String>();
-        String sql = String.format(FIND_COLUMNS, schemaName.toUpperCase(), table.toUpperCase());
-        try (var stmt = connection.createStatement(); var rs = stmt.executeQuery(sql)) {
-            while (rs.next()) {
-                columnsFromTable.add(rs.getString("COLUMN_NAME"));
-            }
-        }
-
-        if (columnsFromTable.isEmpty()) {
-            throw new RuntimeException(
+            if (columnsFromTable.isEmpty()) {
+                throw new RuntimeException(
                     "Empty columns returned from target table " + table + ", schema " + schemaName);
+            }
+
+            columnsFromTable.removeAll(ignoreColumns);
+            var columnsNoDuplicate = columnsFromTable.stream().distinct().toList();
+
+            LOGGER.debug("Columns: {} mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate), table);
+
+            var ingestTableName = String.format("%s%s", table, INGEST_SUFFIX);
+            var columnsFromIngestTable = new ArrayList<String>();
+            columnsFromIngestTable.addAll(columnsFromTable);
+            columnsFromIngestTable.addAll(config.getList(SnowflakeSinkConnector.CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS));
+
+            columnsIngestTable.put(ingestTableName, columnsFromIngestTable);
+            knownIngestTables.add(ingestTableName);
+            columnsFinalTable.put(table, columnsFromTable);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error pre-loading ingest table columns for schema " + schemaName, e);
         }
-
-        columnsFromTable.removeAll(ignoreColumns);
-
-        LOGGER.debug("Columns: {} mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsFromTable), table);
-
-        return columnsFromTable;
     }
 }

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -230,7 +230,7 @@ public abstract class AbstractProcessor {
 
     protected CompressedMap<SnowflakeRecord> getOrCreateBuffer(String tableBaseName) {
         return buffer.computeIfAbsent(tableBaseName, k -> {
-            knownIngestTables.add(tableBaseName + INGEST_SUFFIX);
+            knownIngestTables.add(String.format("%s%s", tableBaseName, INGEST_SUFFIX));
             return new CompressedMap<>(new KryoFactory(), bufferInitialCapacity);
         });
     }

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -43,6 +43,8 @@ public abstract class AbstractProcessor {
     protected Set<String> knownIngestTables = ConcurrentHashMap.newKeySet();
     protected int bufferInitialCapacity;
     protected String tmpDataFolder;
+    protected boolean processMultiTables;
+    protected boolean findInColumnsMetadata;
 
     protected static final String AFTER = "after";
     protected static final String BEFORE = "before";
@@ -59,6 +61,7 @@ public abstract class AbstractProcessor {
     protected static final String REGEX_REPLACEMENT_QUOTE_VALUE = "\"\"";
     protected static final String LINE_SEPARATOR_COMMA = ",";
     protected static final int SB_CSV_INITIAL_SIZE = 1000;
+    protected static final String FILE_SEPARATOR = "/";
 
     protected enum debeziumOperation {
         d,
@@ -71,6 +74,13 @@ public abstract class AbstractProcessor {
 
     private static final String CLIENT_METADATA_USE_SESSION_DATABASE = "CLIENT_METADATA_USE_SESSION_DATABASE";
     private static final String CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX = "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX";
+    private static final String JDBC_QUERY_RESULT_FORMAT = "JDBC_QUERY_RESULT_FORMAT";
+
+    private static final String FIND_COLUMNS = """
+        SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'
+        ORDER BY ORDINAL_POSITION
+        """;
 
     protected abstract void extraConfigsOnStart(AbstractConfig config);
 
@@ -99,6 +109,8 @@ public abstract class AbstractProcessor {
 
         tmpDataFolder = config.getString(SnowflakeSinkConnector.CFG_TMP_DATA_FOLDER);
         bufferInitialCapacity = config.getInt(SnowflakeSinkConnector.CFG_BUFFER_INITIAL_CAPACITY);
+        processMultiTables = config.getBoolean(SnowflakeSinkConnector.CFG_PROCESS_MULTIPLE_TABLES);
+        findInColumnsMetadata = config.getBoolean(SnowflakeSinkConnector.CFG_FIND_COLUMNS_IN_METADATA);
     }
 
     protected void setupSnowflakeConnection(AbstractConfig config) {
@@ -111,6 +123,14 @@ public abstract class AbstractProcessor {
             // evitando SHOW COLUMNS / SHOW OBJECTS implicitos
             properties.put(CLIENT_METADATA_USE_SESSION_DATABASE, "true");
             properties.put(CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX, "true");
+
+            if (!findInColumnsMetadata) {
+                // Desabilita Arrow, usa JSON como formato de resultado
+                // Resolve ExceptionInInitializerError com sun.misc.Unsafe no Java 17+
+                // Ref: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure
+                properties.put(JDBC_QUERY_RESULT_FORMAT, "JSON");
+                LOGGER.warn("Find columns by information_schema query to schema: {}", schemaName);
+            }
 
             connection = DriverManager.getConnection(config.getString(SnowflakeSinkConnector.CFG_URL), properties);
             snowflakeConnection = connection.unwrap(SnowflakeConnection.class);
@@ -139,13 +159,18 @@ public abstract class AbstractProcessor {
         if (columnsIngestTable.containsKey(tableBaseName)) {
             return;
         }
+
         try {
-            String ingestTable = tableBaseName + INGEST_SUFFIX;
-            List<String> ingestCols = getColumnsFromMetadata(ingestTable);
+            String ingestTable = String.format("%s%s", tableBaseName, INGEST_SUFFIX);
+            List<String> ingestCols = findInColumnsMetadata
+                    ? getColumnsFromMetadata(ingestTable)
+                    : getColumnsFromMetadataInformationSchema(ingestTable);
+
             List<String> finalCols = ingestCols.stream()
                     .filter(col -> excludeIngestAdditionalFields.stream()
                             .noneMatch(excluded -> excluded.equalsIgnoreCase(col)))
                     .toList();
+
             columnsIngestTable.put(tableBaseName, ingestCols);
             columnsFinalTable.put(tableBaseName, finalCols);
         } catch (SQLException e) {
@@ -178,8 +203,29 @@ public abstract class AbstractProcessor {
         columnsFromTable.removeAll(ignoreColumns);
         var columnsNoDuplicate = columnsFromTable.stream().distinct().toList();
 
-        LOGGER.debug("Columns mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate));
+        LOGGER.debug("Columns: {} mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate), table);
 
         return columnsNoDuplicate;
+    }
+
+    private List<String> getColumnsFromMetadataInformationSchema(String table) throws SQLException {
+        var columnsFromTable = new ArrayList<String>();
+        String sql = String.format(FIND_COLUMNS, schemaName.toUpperCase(), table.toUpperCase());
+        try (var stmt = connection.createStatement(); var rs = stmt.executeQuery(sql)) {
+            while (rs.next()) {
+                columnsFromTable.add(rs.getString("COLUMN_NAME"));
+            }
+        }
+
+        if (columnsFromTable.isEmpty()) {
+            throw new RuntimeException(
+                    "Empty columns returned from target table " + table + ", schema " + schemaName);
+        }
+
+        columnsFromTable.removeAll(ignoreColumns);
+
+        LOGGER.debug("Columns: {} mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsFromTable), table);
+
+        return columnsFromTable;
     }
 }

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -16,9 +16,12 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class AbstractProcessor {
 
@@ -28,15 +31,16 @@ public abstract class AbstractProcessor {
     protected SnowflakeConnection snowflakeConnection;
     protected String stageName;
     protected String tableName;
-    protected String ingestTableName;
     protected String schemaName;
-    protected List<String> columnsFinalTable = new ArrayList<>();
-    protected List<String> columnsIngestTable = new ArrayList<>();
+    protected Map<String, List<String>> columnsFinalTable = new HashMap<>();
+    protected Map<String, List<String>> columnsIngestTable = new HashMap<>();
     protected List<String> ignoreColumns = new ArrayList<>();
     protected List<String> timestampFieldsConvert = new ArrayList<>();
     protected List<String> dateFieldsConvert = new ArrayList<>();
     protected List<String> timeFieldsConvert = new ArrayList<>();
-    protected CompressedMap<SnowflakeRecord> buffer;
+    protected Map<String, CompressedMap<SnowflakeRecord>> buffer = new HashMap<>();
+    protected Set<String> knownIngestTables = ConcurrentHashMap.newKeySet();
+    protected int bufferInitialCapacity;
     protected String tmpDataFolder;
 
     protected static final String AFTER = "after";
@@ -64,15 +68,8 @@ public abstract class AbstractProcessor {
 
     protected final static String INGEST_SUFFIX = "_INGEST";
 
-    private static final String FIND_COLUMNS = """
-        SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'
-        ORDER BY ORDINAL_POSITION
-        """;
-
     private static final String CLIENT_METADATA_USE_SESSION_DATABASE = "CLIENT_METADATA_USE_SESSION_DATABASE";
     private static final String CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX = "CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX";
-    private static final String JDBC_QUERY_RESULT_FORMAT = "JDBC_QUERY_RESULT_FORMAT";
 
     protected abstract void extraConfigsOnStart(AbstractConfig config);
 
@@ -85,42 +82,12 @@ public abstract class AbstractProcessor {
     protected void start(AbstractConfig config) {
         configParameters(config);
         setupSnowflakeConnection(config);
-
-        if (config.getBoolean(SnowflakeSinkConnector.CFG_FIND_COLUMNS_IN_METADATA)) {
-            configMetadata();
-        } else {
-            configMetadataV2(config);
-        }
-
         extraConfigsOnStart(config);
-    }
-
-    protected void configMetadata() {
-        try {
-            columnsFinalTable = getColumnsFromMetadata(tableName);
-            columnsIngestTable = getColumnsFromMetadata(ingestTableName);
-        } catch (SQLException e) {
-            LOGGER.error("Error while get metadata columns from snowflake", e);
-            throw new RuntimeException("Error while get metadata columns from snowflake", e);
-        }
-    }
-
-    protected void configMetadataV2(AbstractConfig config) {
-        try {
-            columnsIngestTable = getColumnsFromMetadataInformationSchema(ingestTableName);
-            columnsFinalTable = columnsIngestTable.stream()
-                    .filter(cit -> !config.getList(SnowflakeSinkConnector.CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS)
-                            .contains(cit)).toList();
-        } catch (SQLException e) {
-            LOGGER.error("Error while get metadata columns from snowflake", e);
-            throw new RuntimeException("Error while get metadata columns from snowflake", e);
-        }
     }
 
     protected void configParameters(AbstractConfig config) {
         stageName = config.getString(SnowflakeSinkConnector.CFG_STAGE_NAME);
         tableName = config.getString(SnowflakeSinkConnector.CFG_TABLE_NAME);
-        ingestTableName = tableName + INGEST_SUFFIX;
         schemaName = config.getString(SnowflakeSinkConnector.CFG_SCHEMA_NAME);
 
         timestampFieldsConvert.addAll(config.getList(SnowflakeSinkConnector.CFG_TIMESTAMP_FIELDS_CONVERT));
@@ -129,8 +96,7 @@ public abstract class AbstractProcessor {
         ignoreColumns.addAll(config.getList(SnowflakeSinkConnector.CFG_IGNORE_COLUMNS));
 
         tmpDataFolder = config.getString(SnowflakeSinkConnector.CFG_TMP_DATA_FOLDER);
-
-        buffer = new CompressedMap<>(new KryoFactory(), config.getInt(SnowflakeSinkConnector.CFG_BUFFER_INITIAL_CAPACITY));
+        bufferInitialCapacity = config.getInt(SnowflakeSinkConnector.CFG_BUFFER_INITIAL_CAPACITY);
     }
 
     protected void setupSnowflakeConnection(AbstractConfig config) {
@@ -144,20 +110,51 @@ public abstract class AbstractProcessor {
             properties.put(CLIENT_METADATA_USE_SESSION_DATABASE, "true");
             properties.put(CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX, "true");
 
-            // Desabilita Arrow, usa JSON como formato de resultado
-            // Resolve ExceptionInInitializerError com sun.misc.Unsafe no Java 17+
-            // Ref: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure
-            properties.put(JDBC_QUERY_RESULT_FORMAT, "JSON");
-
             connection = DriverManager.getConnection(config.getString(SnowflakeSinkConnector.CFG_URL), properties);
-            snowflakeConnection = connection.unwrap(SnowflakeConnection.class);   // using the provided configuration.
+            snowflakeConnection = connection.unwrap(SnowflakeConnection.class);
         } catch (SQLException e) {
             LOGGER.error("Error while connecting to snowflake connection", e);
             throw new RuntimeException("Error while connecting to snowflake connection", e);
         }
     }
 
-    private List<String> getColumnsFromMetadata(String table) throws SQLException {
+    /**
+     * Returns the table name extracted from the topic (value after the last dot).
+     * Falls back to the configured tableName when the topic has no dot separator.
+     */
+    protected String extractTableNameFromTopic(String topic) {
+        if (topic != null && topic.contains(".")) {
+            return topic.substring(topic.lastIndexOf(".") + 1);
+        }
+        return tableName;
+    }
+
+    /**
+     * Lazily loads and caches column metadata for a table using the JDBC metadata API.
+     * No-op if columns for the table are already cached.
+     */
+    protected void ensureColumnsForTable(String tableBaseName) {
+        if (columnsIngestTable.containsKey(tableBaseName)) {
+            return;
+        }
+        try {
+            String ingestTable = tableBaseName + INGEST_SUFFIX;
+            columnsIngestTable.put(tableBaseName, getColumnsFromMetadata(ingestTable));
+            columnsFinalTable.put(tableBaseName, getColumnsFromMetadata(tableBaseName));
+        } catch (SQLException e) {
+            LOGGER.error("Error while loading metadata columns for table {}", tableBaseName, e);
+            throw new RuntimeException("Error while loading metadata columns for table " + tableBaseName, e);
+        }
+    }
+
+    protected CompressedMap<SnowflakeRecord> getOrCreateBuffer(String tableBaseName) {
+        return buffer.computeIfAbsent(tableBaseName, k -> {
+            knownIngestTables.add(tableBaseName + INGEST_SUFFIX);
+            return new CompressedMap<>(new KryoFactory(), bufferInitialCapacity);
+        });
+    }
+
+    protected List<String> getColumnsFromMetadata(String table) throws SQLException {
         var metadata = connection.getMetaData();
 
         var columnsFromTable = new ArrayList<String>();
@@ -172,32 +169,10 @@ public abstract class AbstractProcessor {
         }
 
         columnsFromTable.removeAll(ignoreColumns);
-        //remove duplicated
         var columnsNoDuplicate = columnsFromTable.stream().distinct().toList();
 
         LOGGER.debug("Columns mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsNoDuplicate));
 
         return columnsNoDuplicate;
-    }
-
-    private List<String> getColumnsFromMetadataInformationSchema(String table) throws SQLException {
-        var columnsFromTable = new ArrayList<String>();
-        String sql = String.format(FIND_COLUMNS, schemaName.toUpperCase(), table.toUpperCase());
-        try (var stmt = connection.createStatement(); var rs = stmt.executeQuery(sql)) {
-            while (rs.next()) {
-                columnsFromTable.add(rs.getString("COLUMN_NAME"));
-            }
-        }
-
-        if (columnsFromTable.isEmpty()) {
-            throw new RuntimeException(
-                    "Empty columns returned from target table " + table + ", schema " + schemaName);
-        }
-
-        columnsFromTable.removeAll(ignoreColumns);
-
-        LOGGER.debug("Columns mapped from target table: {}", String.join(LINE_SEPARATOR_COMMA, columnsFromTable));
-
-        return columnsFromTable;
     }
 }

--- a/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/AbstractProcessor.java
@@ -100,9 +100,13 @@ public abstract class AbstractProcessor {
     protected void start(AbstractConfig config) {
         configParameters(config);
         setupSnowflakeConnection(config);
+
         if (processMultiTables) {
-            preloadAllIngestTableColumns();
+            preloadAllTableColumns();
+        } else {
+            knownIngestTables.add(String.format("%s%s", tableName, INGEST_SUFFIX));
         }
+
         extraConfigsOnStart(config);
     }
 
@@ -151,47 +155,15 @@ public abstract class AbstractProcessor {
         }
     }
 
-    /**
-     * Returns the table name extracted from the topic (value after the last dot).
-     * Falls back to the configured tableName when the topic has no dot separator.
-     */
-    protected String extractTableNameFromTopic(String topic) {
+    protected String extractTableName(String topic) {
         if (topic != null && topic.contains(".") && processMultiTables) {
             return topic.substring(topic.lastIndexOf(".") + 1);
         }
         return tableName;
     }
 
-    /**
-     * Lazily loads and caches column metadata for a table using the JDBC metadata API.
-     * No-op if columns for the table are already cached.
-     */
-    protected void ensureColumnsForTable(String tableBaseName) {
-        if (columnsIngestTable.containsKey(tableBaseName.toUpperCase())) {
-            return;
-        }
-
-        try {
-            String ingestTable = tableBaseName + INGEST_SUFFIX;
-            List<String> ingestCols = findInColumnsMetadata
-                    ? getColumnsFromMetadata(ingestTable)
-                    : getColumnsFromMetadataInformationSchema(ingestTable);
-
-            List<String> finalCols = ingestCols.stream()
-                    .filter(col -> excludeIngestAdditionalFields.stream()
-                            .noneMatch(excluded -> excluded.equalsIgnoreCase(col)))
-                    .toList();
-
-            columnsIngestTable.put(tableBaseName.toUpperCase(), ingestCols);
-            columnsFinalTable.put(tableBaseName.toUpperCase(), finalCols);
-        } catch (SQLException e) {
-            LOGGER.error("Error while loading metadata columns for table {}", tableBaseName, e);
-            throw new RuntimeException("Error while loading metadata columns for table " + tableBaseName, e);
-        }
-    }
-
     // Package-private for testability
-    void preloadAllIngestTableColumns() {
+    void preloadAllTableColumns() {
         String sql = String.format(FIND_ALL_INGEST_TABLE_COLUMNS, schemaName.toUpperCase());
         Map<String, List<String>> rawByIngestTable = new HashMap<>();
 
@@ -206,8 +178,7 @@ public abstract class AbstractProcessor {
         }
 
         if (rawByIngestTable.isEmpty()) {
-            LOGGER.warn("No _INGEST tables found in schema {} during pre-load", schemaName);
-            return;
+            throw new RuntimeException("No _INGEST tables found in schema: " + schemaName + " during pre-load");
         }
 
         for (var entry : rawByIngestTable.entrySet()) {
@@ -222,9 +193,14 @@ public abstract class AbstractProcessor {
                             .noneMatch(excluded -> excluded.equalsIgnoreCase(col)))
                     .toList();
 
-            columnsIngestTable.put(baseTableName, ingestCols);
+            columnsIngestTable.put(ingestTableName, ingestCols);
             columnsFinalTable.put(baseTableName, finalCols);
-            LOGGER.debug("Pre-loaded {} columns for table: {}", ingestCols.size(), baseTableName);
+            knownIngestTables.add(ingestTableName);
+
+            LOGGER.debug("Pre-loaded {} columns for ingest table: {} - Columns names: {}",
+                    ingestCols.size(), ingestTableName, ingestCols);
+            LOGGER.debug("Pre-loaded {} columns from ingest table: {} for final table: {} - Columns names: {}",
+                    finalCols.size(), ingestTableName, baseTableName, finalCols);
         }
 
         LOGGER.info("Pre-loaded columns for {} ingest tables in schema {}", rawByIngestTable.size(), schemaName);

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -128,7 +128,6 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
         for (var entry : buffer.entrySet()) {
             var tableBaseName = entry.getKey();
             var tableBuffer = entry.getValue();
-
             if (!tableBuffer.isEmpty()) {
                 flushTable(tableBaseName, tableBuffer);
             }
@@ -144,7 +143,8 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
         Path tmpFilePathToInsert = null;
 
         try {
-            LOGGER.debug("Preparing to send {} records from buffer. To stage {} and table {}", tableBuffer.size(), stageName, tableBaseName);
+            LOGGER.debug("Preparing to send {} records from buffer. To stage {} and table {}",
+                    tableBuffer.size(), tableBaseName, tableBaseName);
 
             ensureColumnsForTable(tableBaseName);
             var ingestCols = columnsIngestTable.get(tableBaseName);
@@ -152,11 +152,11 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             var tablePks = pksByTable.get(tableBaseName);
             var blockID = UUID.randomUUID().toString();
             var startTimeMain = System.currentTimeMillis();
-            tmpFilePathToInsert = prepareOrderedColumnsBasedOnTargetTable(blockID, ingestCols, tableBuffer);
+            tmpFilePathToInsert = prepareOrderedColumnsBasedOnTargetTable(blockID, ingestCols, tableBuffer, tableBaseName);
 
             try (var inputStream = Files.newInputStream(tmpFilePathToInsert)) {
                 var startTimeUpload = System.currentTimeMillis();
-                snowflakeConnection.uploadStream(stageName, "/", inputStream, destFileName, true);
+                snowflakeConnection.uploadStream(tableBaseName, "/", inputStream, destFileName, true);
                 var endTimeUpload = System.currentTimeMillis();
                 LOGGER.debug("Uploaded {} records in {} ms", tableBuffer.size(), endTimeUpload - startTimeUpload);
 
@@ -164,7 +164,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 try (var stmt = connection.createStatement()) {
 
                     String copyInto = String.format("COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE", ingestTableName,
-                            String.join(",", ingestCols), stageName, destFileName);
+                            String.join(",", ingestCols), tableBaseName, destFileName);
                     LOGGER.debug("Copying statement to ingest table: {}", copyInto);
                     stmt.executeLargeUpdate(copyInto);
 
@@ -222,10 +222,10 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
     }
 
     private void discardData(Path csvToInsert) throws IOException {
-        LOGGER.debug("Discard CSV file data: {} of stage: {} after SnowFlake upload and COPY to ingest table.",
-                csvToInsert.getFileName().toString(), stageName);
+        LOGGER.debug("Discard CSV temp file: {} after SnowFlake upload and COPY to ingest table.",
+                csvToInsert.getFileName().toString());
         Files.deleteIfExists(csvToInsert);
-        LOGGER.debug("Discarded CSV file data: {} of stage: {}.", csvToInsert.getFileName().toString(), stageName);
+        LOGGER.debug("Discarded CSV temp file: {}.", csvToInsert.getFileName().toString());
     }
 
     @Override
@@ -314,7 +314,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 .reduce((a, b) -> String.format("%s and %s", a, b)).orElseThrow();
     }
 
-    protected Path prepareOrderedColumnsBasedOnTargetTable(String blockID, List<String> columnsFromTable, CompressedMap<SnowflakeRecord> tableBuffer) throws Throwable {
+    protected Path prepareOrderedColumnsBasedOnTargetTable(String blockID, List<String> columnsFromTable, CompressedMap<SnowflakeRecord> tableBuffer, String tableBaseName) throws Throwable {
         var startTime = System.currentTimeMillis();
         var stringBuilder = new StringBuilder(tableBuffer.size() * SB_CSV_INITIAL_SIZE);
 
@@ -407,13 +407,13 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
         stringBuilder.trimToSize();
 
-        return this.generateTempFile(stringBuilder, startTime);
+        return this.generateTempFile(stringBuilder, startTime, tableBaseName);
     }
 
-    private Path generateTempFile(StringBuilder stringBuilder, long startTime) throws IOException {
-        Files.createDirectories(Path.of(String.format("%s/%s", tmpDataFolder, stageName)));
+    private Path generateTempFile(StringBuilder stringBuilder, long startTime, String tableBaseName) throws IOException {
+        Files.createDirectories(Path.of(String.format("%s/%s", tmpDataFolder, tableBaseName)));
 
-        var tmpPath = Path.of(String.format("%s/%s/%s.csv", tmpDataFolder, stageName, UUID.randomUUID()));
+        var tmpPath = Path.of(String.format("%s/%s/%s.csv", tmpDataFolder, tableBaseName, UUID.randomUUID()));
         Files.deleteIfExists(tmpPath);
 
         var resultPath = Files.writeString(tmpPath, stringBuilder.toString(), StandardOpenOption.CREATE);

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -146,13 +146,15 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
     @Override
     protected void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-        for (var entry : buffer.entrySet()) {
+        var iterator = buffer.entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
             var tableBaseName = entry.getKey();
             var tableBuffer = entry.getValue();
             if (!tableBuffer.isEmpty()) {
                 flushTable(tableBaseName, processMultiTables ? tableBaseName : stageName, tableBuffer);
             }
-            buffer.remove(tableBaseName);
+            iterator.remove();
         }
     }
 
@@ -167,11 +169,9 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             LOGGER.debug("Preparing to send {} records from buffer. To stage {} and table {}",
                     tableBuffer.size(), stageName, tableBaseName);
 
-            if (processMultiTables) {
-                if (!columnsIngestTable.containsKey(ingestTableName)) {
-                    throw new RuntimeException("No pre-loaded columns for table: " + ingestTableName +
-                            ". Verify the _INGEST table exists in schema " + schemaName);
-                }
+            if (!columnsIngestTable.containsKey(ingestTableName)) {
+                throw new RuntimeException("No pre-loaded columns for table: " + ingestTableName +
+                        ". Verify the _INGEST table exists in schema " + schemaName);
             }
 
             var ingestCols = columnsIngestTable.get(ingestTableName);

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -71,9 +71,6 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 throw new InvalidStructException("Invalid record structure or schema");
             }
 
-            String tableBaseName = extractTableNameFromTopic(record.topic());
-            List<String> tablePks = extractPK(record, tableBaseName);
-
             var fieldOP = record.valueSchema().field(OP);
             if (fieldOP == null) {
                 LOGGER.error("Field '{}' not found in value schema for record: {}", OP, record);
@@ -92,6 +89,9 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                         record.topic(), valueOP, mustProcessReadOnlyMessages);
                 continue;
             }
+
+            String tableBaseName = extractTableNameFromTopic(record.topic());
+            List<String> tablePks = extractPK(record, tableBaseName);
 
             var recordToSnowflake = new SnowflakeRecord(
                     this.prepareEvent(debeziumOperation.d.toString().equalsIgnoreCase(valueOP) ? valueRecord.getStruct(BEFORE) : valueRecord.getStruct(AFTER)),

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -118,7 +118,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             );
 
             LOGGER.trace("Added record to buffer [table={}]: {} with operation {}", tableBaseName, recordToSnowflake, valueOP);
-            getOrCreateBuffer(tableBaseName).put(convertPKToStringKey(record, valueOP, tablePks), recordToSnowflake);
+            getOrCreateBuffer(tableBaseName).put(convertPKToStringKey(record, tablePks), recordToSnowflake);
         }
     }
 
@@ -307,7 +307,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
         });
     }
 
-    private String convertPKToStringKey(SinkRecord record, String valueOP, List<String> pks) {
+    private String convertPKToStringKey(SinkRecord record, List<String> pks) {
         var keyStruct = (Struct) record.key();
         var pkValues = new ArrayList<String>();
         for (String pk : pks) {
@@ -318,7 +318,6 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             }
             pkValues.add(value.toString());
         }
-        pkValues.add(valueOP);
 
         return String.join("+", pkValues);
     }

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -118,7 +118,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             );
 
             LOGGER.trace("Added record to buffer [table={}]: {} with operation {}", tableBaseName, recordToSnowflake, valueOP);
-            getOrCreateBuffer(tableBaseName).put(convertPKToStringKey(record, tablePks), recordToSnowflake);
+            getOrCreateBuffer(tableBaseName).put(convertPKToStringKey(record, valueOP, tablePks), recordToSnowflake);
         }
     }
 
@@ -307,7 +307,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
         });
     }
 
-    private String convertPKToStringKey(SinkRecord record, List<String> pks) {
+    private String convertPKToStringKey(SinkRecord record, String valueOP, List<String> pks) {
         var keyStruct = (Struct) record.key();
         var pkValues = new ArrayList<String>();
         for (String pk : pks) {
@@ -318,6 +318,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             }
             pkValues.add(value.toString());
         }
+        pkValues.add(valueOP);
 
         return String.join("+", pkValues);
     }

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -129,13 +129,13 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             var tableBaseName = entry.getKey();
             var tableBuffer = entry.getValue();
             if (!tableBuffer.isEmpty()) {
-                flushTable(tableBaseName, tableBuffer);
+                flushTable(tableBaseName, processMultiTables ? tableBaseName : stageName, tableBuffer);
             }
             buffer.remove(tableBaseName);
         }
     }
 
-    private void flushTable(String tableBaseName, CompressedMap<SnowflakeRecord> tableBuffer) {
+    private void flushTable(String tableBaseName, String stageName, CompressedMap<SnowflakeRecord> tableBuffer) {
         var startTime = System.currentTimeMillis();
         var totalBuffer = tableBuffer.size();
         var ingestTableName = tableBaseName + INGEST_SUFFIX;
@@ -144,7 +144,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
         try {
             LOGGER.debug("Preparing to send {} records from buffer. To stage {} and table {}",
-                    tableBuffer.size(), tableBaseName, tableBaseName);
+                    tableBuffer.size(), stageName, tableBaseName);
 
             ensureColumnsForTable(tableBaseName);
             var ingestCols = columnsIngestTable.get(tableBaseName);
@@ -156,16 +156,17 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
             try (var inputStream = Files.newInputStream(tmpFilePathToInsert)) {
                 var startTimeUpload = System.currentTimeMillis();
-                snowflakeConnection.uploadStream(tableBaseName, "/", inputStream, destFileName, true);
+                snowflakeConnection.uploadStream(stageName, FILE_SEPARATOR, inputStream, destFileName, true);
                 var endTimeUpload = System.currentTimeMillis();
                 LOGGER.debug("Uploaded {} records in {} ms", tableBuffer.size(), endTimeUpload - startTimeUpload);
 
                 var startTimeStatement = System.currentTimeMillis();
                 try (var stmt = connection.createStatement()) {
-
                     String copyInto = String.format("COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE", ingestTableName,
-                            String.join(",", ingestCols), tableBaseName, destFileName);
+                            String.join(LINE_SEPARATOR_COMMA, ingestCols), stageName, destFileName);
+
                     LOGGER.debug("Copying statement to ingest table: {}", copyInto);
+
                     stmt.executeLargeUpdate(copyInto);
 
                     this.discardData(tmpFilePathToInsert);
@@ -314,7 +315,8 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 .reduce((a, b) -> String.format("%s and %s", a, b)).orElseThrow();
     }
 
-    protected Path prepareOrderedColumnsBasedOnTargetTable(String blockID, List<String> columnsFromTable, CompressedMap<SnowflakeRecord> tableBuffer, String tableBaseName) throws Throwable {
+    protected Path prepareOrderedColumnsBasedOnTargetTable(String blockID, List<String> columnsFromTable,
+                                                           CompressedMap<SnowflakeRecord> tableBuffer, String tableBaseName) throws Throwable {
         var startTime = System.currentTimeMillis();
         var stringBuilder = new StringBuilder(tableBuffer.size() * SB_CSV_INITIAL_SIZE);
 
@@ -411,9 +413,9 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
     }
 
     private Path generateTempFile(StringBuilder stringBuilder, long startTime, String tableBaseName) throws IOException {
-        Files.createDirectories(Path.of(String.format("%s/%s", tmpDataFolder, tableBaseName)));
+        Files.createDirectories(Path.of(String.format("%s/%s/%s", tmpDataFolder, schemaName, tableBaseName)));
 
-        var tmpPath = Path.of(String.format("%s/%s/%s.csv", tmpDataFolder, tableBaseName, UUID.randomUUID()));
+        var tmpPath = Path.of(String.format("%s/%s/%s/%s.csv", tmpDataFolder, schemaName, tableBaseName, UUID.randomUUID()));
         Files.deleteIfExists(tmpPath);
 
         var resultPath = Files.writeString(tmpPath, stringBuilder.toString(), StandardOpenOption.CREATE);

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -1,5 +1,6 @@
 package br.com.datastreambrasil.v3;
 
+import br.com.datastreambrasil.v3.compress.CompressedMap;
 import br.com.datastreambrasil.v3.exception.InvalidStructException;
 import br.com.datastreambrasil.v3.model.FieldRecord;
 import br.com.datastreambrasil.v3.model.SnowflakeRecord;
@@ -41,11 +42,12 @@ import java.util.UUID;
 /**
  * CdcDbzSchemaProcessor receives SinkRecords using Struct with Schema in CDC Debezium format.
  * This processor will process all operations (snapshot,insert, update, delete) and save on snowflake.
+ * Supports multiple tables per DB/schema: the table name is extracted from the topic (value after the last dot).
  */
 public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
     private Scheduler scheduler;
-    private List<String> pks = new ArrayList<>();
+    private Map<String, List<String>> pksByTable = new HashMap<>();
     private boolean flushHasDeletedRecords;
     private boolean flushHasInsertedRecords;
     private boolean flushHasUpdatedRecords;
@@ -62,14 +64,15 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
     @Override
     protected void put(Collection<SinkRecord> collection) {
-        LOGGER.info("PUT - Total number of records to be stored in the buffer: {}", collection.size());
+        LOGGER.debug("PUT - Total number of records to be stored in the buffer: {}", collection.size());
         for (SinkRecord record : collection) {
 
             if (!validate(record)) {
                 throw new InvalidStructException("Invalid record structure or schema");
             }
 
-            pks = extractPK(record);
+            String tableBaseName = extractTableNameFromTopic(record.topic());
+            List<String> tablePks = extractPK(record, tableBaseName);
 
             var fieldOP = record.valueSchema().field(OP);
             if (fieldOP == null) {
@@ -93,8 +96,8 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                     LocalDateTime.now(ZoneOffset.UTC)
             );
 
-            LOGGER.trace("Added record to buffer: {} with operation {}", recordToSnowflake, valueOP);
-            buffer.put(convertPKToStringKey(record), recordToSnowflake);
+            LOGGER.trace("Added record to buffer [table={}]: {} with operation {}", tableBaseName, recordToSnowflake, valueOP);
+            getOrCreateBuffer(tableBaseName).put(convertPKToStringKey(record, tablePks), recordToSnowflake);
         }
     }
 
@@ -122,60 +125,68 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
     @Override
     protected void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-        var startTime = System.currentTimeMillis();
-        if (buffer.isEmpty()) {
-            return;
-        }
+        for (var entry : buffer.entrySet()) {
+            var tableBaseName = entry.getKey();
+            var tableBuffer = entry.getValue();
 
-        var totalBuffer = buffer.size();
+            if (!tableBuffer.isEmpty()) {
+                flushTable(tableBaseName, tableBuffer);
+            }
+            buffer.remove(tableBaseName);
+        }
+    }
+
+    private void flushTable(String tableBaseName, CompressedMap<SnowflakeRecord> tableBuffer) {
+        var startTime = System.currentTimeMillis();
+        var totalBuffer = tableBuffer.size();
+        var ingestTableName = tableBaseName + INGEST_SUFFIX;
         var destFileName = UUID.randomUUID().toString();
         Path tmpFilePathToInsert = null;
-        try {
-            LOGGER.debug("Preparing to send {} records from buffer. To stage {} and table {}", buffer.size(), stageName,
-                    tableName);
 
-            var columnsFromMetadata = columnsIngestTable;
+        try {
+            LOGGER.debug("Preparing to send {} records from buffer. To stage {} and table {}", tableBuffer.size(), stageName, tableBaseName);
+
+            ensureColumnsForTable(tableBaseName);
+            var ingestCols = columnsIngestTable.get(tableBaseName);
+            var finalCols = columnsFinalTable.get(tableBaseName);
+            var tablePks = pksByTable.get(tableBaseName);
             var blockID = UUID.randomUUID().toString();
             var startTimeMain = System.currentTimeMillis();
-            tmpFilePathToInsert = prepareOrderedColumnsBasedOnTargetTable(blockID, columnsFromMetadata);
+            tmpFilePathToInsert = prepareOrderedColumnsBasedOnTargetTable(blockID, ingestCols, tableBuffer);
 
             try (var inputStream = Files.newInputStream(tmpFilePathToInsert)) {
                 var startTimeUpload = System.currentTimeMillis();
                 snowflakeConnection.uploadStream(stageName, "/", inputStream, destFileName, true);
                 var endTimeUpload = System.currentTimeMillis();
-                LOGGER.debug("Uploaded {} records in {} ms", buffer.size(), endTimeUpload - startTimeUpload);
+                LOGGER.debug("Uploaded {} records in {} ms", tableBuffer.size(), endTimeUpload - startTimeUpload);
 
                 var startTimeStatement = System.currentTimeMillis();
                 try (var stmt = connection.createStatement()) {
 
-                    //copy everything to ingest
                     String copyInto = String.format("COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE", ingestTableName,
-                            String.join(",", columnsFromMetadata), stageName, destFileName);
+                            String.join(",", ingestCols), stageName, destFileName);
                     LOGGER.debug("Copying statement to ingest table: {}", copyInto);
                     stmt.executeLargeUpdate(copyInto);
 
-                    // Delete temp file after SnowFlake upload and COPY to ingest table and clear buffer.
                     this.discardData(tmpFilePathToInsert);
 
                     if (flushHasInsertedRecords || flushHasUpdatedRecords) {
-                        //insert/update in final table
                         String merge = String.format("MERGE INTO %s AS final USING (SELECT * EXCLUDE (%s) FROM %s WHERE ih_blockid = '%s' and ih_op in ('c', 'r', 'u')) AS ingest ON %s " +
                                         "WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s) " +
                                         "WHEN MATCHED THEN UPDATE SET %s",
-                                tableName, buildExcludeColumns(), ingestTableName, blockID,
-                                buildPkWhereClause(pks), String.join(",", columnsFinalTable),
-                                String.join(",", columnsFinalTable.stream().map(c -> "ingest." + c).toList()),
-                                buildUpdateColumns());
+                                tableBaseName, buildExcludeColumns(), ingestTableName, blockID,
+                                buildPkWhereClause(tablePks), String.join(",", finalCols),
+                                String.join(",", finalCols.stream().map(c -> "ingest." + c).toList()),
+                                buildUpdateColumns(finalCols));
                         LOGGER.debug("Merging statement to final table: {}", merge);
                         stmt.executeLargeUpdate(merge);
                     }
 
-                    //delete from final table
                     if (flushHasDeletedRecords) {
                         String deleteFromFinalTable = String.format(
                                 "DELETE FROM %s as final USING (SELECT %s FROM %s WHERE ih_blockid = '%s' and ih_op = 'd') AS ingest WHERE %s",
-                                tableName, String.join(",", pks), ingestTableName, blockID,
-                                buildPkWhereClause(pks));
+                                tableBaseName, String.join(",", tablePks), ingestTableName, blockID,
+                                buildPkWhereClause(tablePks));
                         LOGGER.debug("Deleting statement from final table: {}", deleteFromFinalTable);
                         stmt.executeLargeUpdate(deleteFromFinalTable);
                     }
@@ -191,7 +202,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             LOGGER.debug("Process records took {} ms", endTimeMain - startTimeMain);
 
         } catch (Throwable e) {
-            LOGGER.error("Error while flushing Snowflake connector", e);
+            LOGGER.error("Error while flushing Snowflake connector for table {}", tableBaseName, e);
 
             if (tmpFilePathToInsert != null) {
                 try {
@@ -202,18 +213,17 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 }
             }
 
-            throw new RuntimeException("Error while flushing", e);
+            throw new RuntimeException("Error while flushing table " + tableBaseName, e);
         } finally {
             var endTime = System.currentTimeMillis();
             LOGGER.debug("Flushed {} records in {} ms", totalBuffer, endTime - startTime);
-            buffer.clear();
+            tableBuffer.clear();
         }
     }
 
     private void discardData(Path csvToInsert) throws IOException {
-        LOGGER.debug("Discard buffer and CSV file data: {} of stage: {} after SnowFlake upload and COPY to ingest table.",
+        LOGGER.debug("Discard CSV file data: {} of stage: {} after SnowFlake upload and COPY to ingest table.",
                 csvToInsert.getFileName().toString(), stageName);
-        buffer.clear();
         Files.deleteIfExists(csvToInsert);
         LOGGER.debug("Discarded CSV file data: {} of stage: {}.", csvToInsert.getFileName().toString(), stageName);
     }
@@ -241,10 +251,9 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
         var durationCleanup = Duration.parse(config.getString(SnowflakeSinkConnector.CFG_JOB_CLEANUP_DURATION));
         LOGGER.info("Cleanup job will run every {} seconds", durationCleanup.toSeconds());
 
-        // job quartz config
         var jobData = new HashMap<String, Object>();
         jobData.put(CleanupJob.SNOWFLAKE_CONNECTION, connection);
-        jobData.put(CleanupJob.INGEST_TABLE_NAME, ingestTableName);
+        jobData.put(CleanupJob.INGEST_TABLE_NAMES, knownIngestTables);
 
         var props = new Properties();
         props.setProperty(StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME, String.format("cleanup_%s", UUID.randomUUID()));
@@ -262,17 +271,17 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
         scheduler.start();
     }
 
-    private List<String> extractPK(SinkRecord record) {
-        if (pks.isEmpty()) {
+    private List<String> extractPK(SinkRecord record, String tableBaseName) {
+        return pksByTable.computeIfAbsent(tableBaseName, k -> {
+            var pks = new ArrayList<String>();
             for (Field field : record.keySchema().fields()) {
                 pks.add(field.name());
             }
-        }
-
-        return pks;
+            return pks;
+        });
     }
 
-    private String convertPKToStringKey(SinkRecord record) {
+    private String convertPKToStringKey(SinkRecord record, List<String> pks) {
         var keyStruct = (Struct) record.key();
         var pkValues = new ArrayList<String>();
         for (String pk : pks) {
@@ -287,9 +296,9 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
         return String.join("+", pkValues);
     }
 
-    private String buildUpdateColumns() {
+    private String buildUpdateColumns(List<String> finalCols) {
         var columns = new ArrayList<String>();
-        for (String column : columnsFinalTable) {
+        for (String column : finalCols) {
             columns.add(String.format("final.%s = ingest.%s", column, column));
         }
         return String.join(",", columns);
@@ -305,17 +314,17 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 .reduce((a, b) -> String.format("%s and %s", a, b)).orElseThrow();
     }
 
-    protected Path prepareOrderedColumnsBasedOnTargetTable(String blockID, List<String> columnsFromTable) throws Throwable {
+    protected Path prepareOrderedColumnsBasedOnTargetTable(String blockID, List<String> columnsFromTable, CompressedMap<SnowflakeRecord> tableBuffer) throws Throwable {
         var startTime = System.currentTimeMillis();
-        var stringBuilder = new StringBuilder(buffer.size() * SB_CSV_INITIAL_SIZE);
+        var stringBuilder = new StringBuilder(tableBuffer.size() * SB_CSV_INITIAL_SIZE);
 
         flushHasDeletedRecords = false;
         flushHasUpdatedRecords = false;
         flushHasInsertedRecords = false;
 
         boolean loggedDebugForFirstLine = false;
-        for (var recordInBuffer : buffer.values()) {
-            var recordData = buffer.deserializeValue(recordInBuffer);
+        for (var recordInBuffer : tableBuffer.values()) {
+            var recordData = tableBuffer.deserializeValue(recordInBuffer);
             var count = 0;
             var op = recordData.op();
 

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -46,6 +46,20 @@ import java.util.UUID;
  */
 public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
+    private static final String INGEST_TABLE_NAME_MASK = "%s%s";
+
+    private static final String MERGE_QUERY = """
+            MERGE INTO %s AS final USING (SELECT * EXCLUDE (%s) FROM %s
+            WHERE ih_blockid = '%s'
+            and ih_op in ('c', 'r', 'u')) AS ingest ON %s
+            WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)
+            WHEN MATCHED THEN UPDATE SET %s""";
+
+    private static final String COPY_QUERY = "COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE";
+    private static final String DELETE_QUERY = """
+            DELETE FROM %s as final USING (SELECT %s FROM %s WHERE ih_blockid = '%s' and ih_op = 'd') AS ingest
+            WHERE %s""";
+
     private Scheduler scheduler;
     private Map<String, List<String>> pksByTable = new HashMap<>();
     private boolean flushHasDeletedRecords;
@@ -66,7 +80,6 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
     protected void put(Collection<SinkRecord> collection) {
         LOGGER.debug("PUT - Total number of records to be stored in the buffer: {}", collection.size());
         for (SinkRecord record : collection) {
-
             if (!validate(record)) {
                 throw new InvalidStructException("Invalid record structure or schema");
             }
@@ -90,7 +103,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 continue;
             }
 
-            String tableBaseName = extractTableNameFromTopic(record.topic());
+            String tableBaseName = extractTableName(record.topic());
             List<String> tablePks = extractPK(record, tableBaseName);
 
             var recordToSnowflake = new SnowflakeRecord(
@@ -144,7 +157,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
     private void flushTable(String tableBaseName, String stageName, CompressedMap<SnowflakeRecord> tableBuffer) {
         var startTime = System.currentTimeMillis();
         var totalBuffer = tableBuffer.size();
-        var ingestTableName = tableBaseName + INGEST_SUFFIX;
+        var ingestTableName = String.format(INGEST_TABLE_NAME_MASK, tableBaseName, INGEST_SUFFIX);
         var destFileName = UUID.randomUUID().toString();
         Path tmpFilePathToInsert = null;
 
@@ -157,11 +170,9 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                     throw new RuntimeException("No pre-loaded columns for table: " + tableBaseName +
                             ". Verify the _INGEST table exists in schema " + schemaName);
                 }
-            } else {
-                ensureColumnsForTable(tableBaseName);
             }
 
-            var ingestCols = columnsIngestTable.get(tableBaseName.toUpperCase());
+            var ingestCols = columnsIngestTable.get(ingestTableName.toUpperCase());
             var finalCols = columnsFinalTable.get(tableBaseName.toUpperCase());
             var tablePks = pksByTable.get(tableBaseName);
             var blockID = UUID.randomUUID().toString();
@@ -176,7 +187,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
                 var startTimeStatement = System.currentTimeMillis();
                 try (var stmt = connection.createStatement()) {
-                    String copyInto = String.format("COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE", ingestTableName,
+                    String copyInto = String.format(COPY_QUERY, ingestTableName,
                             String.join(LINE_SEPARATOR_COMMA, ingestCols), stageName, destFileName);
 
                     LOGGER.debug("Copying statement to ingest table: {}", copyInto);
@@ -186,22 +197,18 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                     this.discardData(tmpFilePathToInsert);
 
                     if (flushHasInsertedRecords || flushHasUpdatedRecords) {
-                        String merge = String.format("MERGE INTO %s AS final USING (SELECT * EXCLUDE (%s) FROM %s WHERE ih_blockid = '%s' and ih_op in ('c', 'r', 'u')) AS ingest ON %s " +
-                                        "WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s) " +
-                                        "WHEN MATCHED THEN UPDATE SET %s",
-                                tableBaseName, buildExcludeColumns(), ingestTableName, blockID,
-                                buildPkWhereClause(tablePks), String.join(",", finalCols),
-                                String.join(",", finalCols.stream().map(c -> "ingest." + c).toList()),
+                        String merge = String.format(MERGE_QUERY, tableBaseName, buildExcludeColumns(), ingestTableName,
+                                blockID, buildPkWhereClause(tablePks), String.join(LINE_SEPARATOR_COMMA, finalCols),
+                                String.join(LINE_SEPARATOR_COMMA, finalCols.stream().map(c -> String.format("ingest.%s", c)).toList()),
                                 buildUpdateColumns(finalCols));
                         LOGGER.debug("Merging statement to final table: {}", merge);
                         stmt.executeLargeUpdate(merge);
                     }
 
                     if (flushHasDeletedRecords) {
-                        String deleteFromFinalTable = String.format(
-                                "DELETE FROM %s as final USING (SELECT %s FROM %s WHERE ih_blockid = '%s' and ih_op = 'd') AS ingest WHERE %s",
-                                tableBaseName, String.join(",", tablePks), ingestTableName, blockID,
-                                buildPkWhereClause(tablePks));
+                        String deleteFromFinalTable = String.format(DELETE_QUERY, tableBaseName,
+                                String.join(",", tablePks), ingestTableName,
+                                blockID, buildPkWhereClause(tablePks));
                         LOGGER.debug("Deleting statement from final table: {}", deleteFromFinalTable);
                         stmt.executeLargeUpdate(deleteFromFinalTable);
                     }
@@ -255,7 +262,6 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
     }
 
     protected void startCleanUpJob(AbstractConfig config) throws SchedulerException {
-
         var disableCleanUpJob = config.getBoolean(SnowflakeSinkConnector.CFG_JOB_CLEANUP_DISABLE);
 
         if (disableCleanUpJob) {
@@ -276,12 +282,15 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
         var schedulerFactory = new StdSchedulerFactory(props);
         scheduler = schedulerFactory.getScheduler();
+
         var job = JobBuilder.newJob(CleanupJob.class).withIdentity("cleanupjob")
                 .setJobData(new JobDataMap(jobData))
                 .build();
+
         var trigger = TriggerBuilder.newTrigger().withIdentity("trigger_cleanupjob")
                 .withSchedule(SimpleScheduleBuilder.repeatSecondlyForever((int) durationCleanup.getSeconds()))
                 .build();
+
         scheduler.scheduleJob(job, trigger);
         scheduler.start();
     }

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -146,9 +146,17 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             LOGGER.debug("Preparing to send {} records from buffer. To stage {} and table {}",
                     tableBuffer.size(), stageName, tableBaseName);
 
-            ensureColumnsForTable(tableBaseName);
-            var ingestCols = columnsIngestTable.get(tableBaseName);
-            var finalCols = columnsFinalTable.get(tableBaseName);
+            if (processMultiTables) {
+                if (!columnsIngestTable.containsKey(tableBaseName.toUpperCase())) {
+                    throw new RuntimeException("No pre-loaded columns for table: " + tableBaseName +
+                            ". Verify the _INGEST table exists in schema " + schemaName);
+                }
+            } else {
+                ensureColumnsForTable(tableBaseName);
+            }
+
+            var ingestCols = columnsIngestTable.get(tableBaseName.toUpperCase());
+            var finalCols = columnsFinalTable.get(tableBaseName.toUpperCase());
             var tablePks = pksByTable.get(tableBaseName);
             var blockID = UUID.randomUUID().toString();
             var startTimeMain = System.currentTimeMillis();

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -87,6 +87,12 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 throw new InvalidStructException("Value for field '" + OP + "' is null");
             }
 
+            if (debeziumOperation.r.toString().equalsIgnoreCase(valueOP) && !mustProcessReadOnlyMessages) {
+                LOGGER.debug("Read message of topic: {}, discarded. Type: {}, parameter mustProcessReadOnlyMessages: {}",
+                        record.topic(), valueOP, mustProcessReadOnlyMessages);
+                continue;
+            }
+
             var recordToSnowflake = new SnowflakeRecord(
                     this.prepareEvent(debeziumOperation.d.toString().equalsIgnoreCase(valueOP) ? valueRecord.getStruct(BEFORE) : valueRecord.getStruct(AFTER)),
                     record.topic(),

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -55,7 +55,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)
             WHEN MATCHED AND HASH(%s) <> HASH(%s) THEN UPDATE SET %s""";
 
-    private static final String COPY_QUERY = "COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE";
+    private static final String COPY_QUERY = "COPY INTO %s (%s) FROM @%s/%s.gz PURGE = '%s'";
     private static final String DELETE_QUERY = """
             DELETE FROM %s as final USING (SELECT %s FROM %s
             WHERE ih_blockid = '%s' and ih_op = 'd') AS ingest
@@ -190,13 +190,18 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                 var startTimeStatement = System.currentTimeMillis();
                 try (var stmt = connection.createStatement()) {
                     String copyInto = String.format(COPY_QUERY, ingestTableName,
-                            String.join(LINE_SEPARATOR_COMMA, ingestCols), stageName, destFileName);
+                            String.join(LINE_SEPARATOR_COMMA, ingestCols), stageName, destFileName, copyOnly ? "FALSE" : "TRUE");
 
                     LOGGER.debug("Copying statement to ingest table: {}", copyInto);
 
                     stmt.executeLargeUpdate(copyInto);
 
                     this.discardData(tmpFilePathToInsert);
+
+                    if (copyOnly) {
+                        LOGGER.debug("COPY_ONLY is true, skipping insert/update/delete in final table.");
+                        return;
+                    }
 
                     if (flushHasInsertedRecords || flushHasUpdatedRecords) {
                         String merge = String.format(MERGE_QUERY, tableBaseName, buildExcludeColumns(), ingestTableName,

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -57,8 +57,10 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
 
     private static final String COPY_QUERY = "COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE";
     private static final String DELETE_QUERY = """
-            DELETE FROM %s as final USING (SELECT %s FROM %s WHERE ih_blockid = '%s' and ih_op = 'd') AS ingest
-            WHERE %s""";
+            DELETE FROM %s as final USING (SELECT %s FROM %s
+            WHERE ih_blockid = '%s' and ih_op = 'd') AS ingest
+            WHERE %s
+            """;
 
     private Scheduler scheduler;
     private Map<String, List<String>> pksByTable = new HashMap<>();
@@ -157,7 +159,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
     private void flushTable(String tableBaseName, String stageName, CompressedMap<SnowflakeRecord> tableBuffer) {
         var startTime = System.currentTimeMillis();
         var totalBuffer = tableBuffer.size();
-        var ingestTableName = String.format(INGEST_TABLE_NAME_MASK, tableBaseName, INGEST_SUFFIX);
+        var ingestTableName = String.format(INGEST_TABLE_NAME_MASK, tableBaseName, INGEST_SUFFIX).toUpperCase();
         var destFileName = UUID.randomUUID().toString();
         Path tmpFilePathToInsert = null;
 
@@ -166,13 +168,13 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                     tableBuffer.size(), stageName, tableBaseName);
 
             if (processMultiTables) {
-                if (!columnsIngestTable.containsKey(tableBaseName.toUpperCase())) {
-                    throw new RuntimeException("No pre-loaded columns for table: " + tableBaseName +
+                if (!columnsIngestTable.containsKey(ingestTableName)) {
+                    throw new RuntimeException("No pre-loaded columns for table: " + ingestTableName +
                             ". Verify the _INGEST table exists in schema " + schemaName);
                 }
             }
 
-            var ingestCols = columnsIngestTable.get(ingestTableName.toUpperCase());
+            var ingestCols = columnsIngestTable.get(ingestTableName);
             var finalCols = columnsFinalTable.get(tableBaseName.toUpperCase());
             var tablePks = pksByTable.get(tableBaseName);
             var blockID = UUID.randomUUID().toString();

--- a/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessor.java
@@ -53,7 +53,7 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             WHERE ih_blockid = '%s'
             and ih_op in ('c', 'r', 'u')) AS ingest ON %s
             WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)
-            WHEN MATCHED THEN UPDATE SET %s""";
+            WHEN MATCHED AND HASH(%s) <> HASH(%s) THEN UPDATE SET %s""";
 
     private static final String COPY_QUERY = "COPY INTO %s (%s) FROM @%s/%s.gz PURGE = TRUE";
     private static final String DELETE_QUERY = """
@@ -202,6 +202,8 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
                         String merge = String.format(MERGE_QUERY, tableBaseName, buildExcludeColumns(), ingestTableName,
                                 blockID, buildPkWhereClause(tablePks), String.join(LINE_SEPARATOR_COMMA, finalCols),
                                 String.join(LINE_SEPARATOR_COMMA, finalCols.stream().map(c -> String.format("ingest.%s", c)).toList()),
+                                buildHashExpression("final", finalCols),
+                                buildHashExpression("ingest", finalCols),
                                 buildUpdateColumns(finalCols));
                         LOGGER.debug("Merging statement to final table: {}", merge);
                         stmt.executeLargeUpdate(merge);
@@ -328,6 +330,12 @@ public class CdcDbzSchemaProcessor extends AbstractProcessor {
             columns.add(String.format("final.%s = ingest.%s", column, column));
         }
         return String.join(",", columns);
+    }
+
+    private String buildHashExpression(String alias, List<String> cols) {
+        return String.join(",", cols.stream()
+                .map(col -> String.format("%s.%s", alias, col))
+                .toList());
     }
 
     private String buildExcludeColumns() {

--- a/src/main/java/br/com/datastreambrasil/v3/CleanupJob.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CleanupJob.java
@@ -7,32 +7,39 @@ import org.quartz.JobExecutionContext;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Set;
 
 public class CleanupJob implements Job {
 
     private static final Logger LOGGER = LogManager.getLogger(CleanupJob.class);
 
-    protected static final String INGEST_TABLE_NAME = "ingest_table_name";
+    protected static final String INGEST_TABLE_NAMES = "ingest_table_names";
     protected static final String SNOWFLAKE_CONNECTION = "snowflake_connection";
 
     @Override
     public void execute(JobExecutionContext context) {
         var jobData = context.getMergedJobDataMap();
-        var ingest = (String) jobData.get(INGEST_TABLE_NAME);
+        @SuppressWarnings("unchecked")
+        var ingestTables = (Set<String>) jobData.get(INGEST_TABLE_NAMES);
         var connection = (Connection) jobData.get(SNOWFLAKE_CONNECTION);
 
-        // we delete records older than 4 hours only
-        var deleteQuery = String.format("""
-                    delete from %s ingest where ih_datetime + interval '%s hour' < sysdate()
-            """, ingest, 4);
-
-        LOGGER.debug("Executing delete query: {}", deleteQuery);
-        try (var stmt = connection.createStatement()) {
-            stmt.executeLargeUpdate(deleteQuery);
-        } catch (SQLException e) {
-            LOGGER.error("Error while executing delete query", e);
+        if (ingestTables == null || ingestTables.isEmpty()) {
+            LOGGER.debug("No ingest tables registered yet, skipping cleanup.");
+            return;
         }
 
+        for (var ingest : ingestTables) {
+            var deleteQuery = String.format("""
+                        delete from %s ingest where ih_datetime + interval '%s hour' < sysdate()
+                """, ingest, 4);
+
+            LOGGER.debug("Executing delete query: {}", deleteQuery);
+            try (var stmt = connection.createStatement()) {
+                stmt.executeLargeUpdate(deleteQuery);
+            } catch (SQLException e) {
+                LOGGER.error("Error while executing delete query for table {}", ingest, e);
+            }
+        }
     }
 
 }

--- a/src/main/java/br/com/datastreambrasil/v3/CleanupJob.java
+++ b/src/main/java/br/com/datastreambrasil/v3/CleanupJob.java
@@ -41,5 +41,4 @@ public class CleanupJob implements Job {
             }
         }
     }
-
 }

--- a/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
+++ b/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
@@ -36,6 +36,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
     protected static final String CFG_FIND_COLUMNS_IN_METADATA = "find_columns_in_metadata";
     protected static final String CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS = "exclude_ingest_additional_fields";
     protected static final String CFG_PROCESS_MULTIPLE_TABLES = "process_multiples_tables";
+    protected static final String CFG_MUST_PROCESS_READ_ONLY_MESSAGES = "must_process_read_only_messages";
 
     /*
      * For some use cases we need to load all data again, each time. So we have two
@@ -114,7 +115,10 @@ public class SnowflakeSinkConnector extends SinkConnector {
                 "Defines which fields from the ingest table should be disregarded in the final table.")
         .define(CFG_PROCESS_MULTIPLE_TABLES, ConfigDef.Type.BOOLEAN, Boolean.FALSE,
                 ConfigDef.Importance.HIGH,
-                "Determine whether to process multiple tables.");
+                "Determine whether to process multiple tables.")
+        .define(CFG_MUST_PROCESS_READ_ONLY_MESSAGES, ConfigDef.Type.BOOLEAN, Boolean.TRUE,
+                ConfigDef.Importance.HIGH,
+                "Determines whether to process read-only messages.");
 
     private Map<String, String> props;
 

--- a/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
+++ b/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
@@ -37,6 +37,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
     protected static final String CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS = "exclude_ingest_additional_fields";
     protected static final String CFG_PROCESS_MULTIPLE_TABLES = "process_multiples_tables";
     protected static final String CFG_MUST_PROCESS_READ_ONLY_MESSAGES = "must_process_read_only_messages";
+    protected static final String CFG_TABLES_FIELDS = "tables_fields";
 
     /*
      * For some use cases we need to load all data again, each time. So we have two
@@ -118,7 +119,10 @@ public class SnowflakeSinkConnector extends SinkConnector {
                 "Determine whether to process multiple tables.")
         .define(CFG_MUST_PROCESS_READ_ONLY_MESSAGES, ConfigDef.Type.BOOLEAN, Boolean.TRUE,
                 ConfigDef.Importance.HIGH,
-                "Determines whether to process read-only messages.");
+                "Determines whether to process read-only messages.")
+        .define(CFG_TABLES_FIELDS, ConfigDef.Type.STRING, null,
+                ConfigDef.Importance.HIGH,
+                "Defines the names of the fields and tables to be processed, disabling column lookup in the database. Format: table1-field1,fieldX|table2-field1,fieldX.");
 
     private Map<String, String> props;
 

--- a/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
+++ b/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
@@ -106,7 +106,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
         .define(CFG_BUFFER_INITIAL_CAPACITY, ConfigDef.Type.INT, 1000000,
                 ConfigDef.Importance.HIGH,
                 "The initial buffer capacity.")
-        .define(CFG_FIND_COLUMNS_IN_METADATA, ConfigDef.Type.BOOLEAN, Boolean.FALSE,
+        .define(CFG_FIND_COLUMNS_IN_METADATA, ConfigDef.Type.BOOLEAN, Boolean.TRUE,
                 ConfigDef.Importance.HIGH,
                 "Define whether to retrieve column names from the metadata or by querying the information schema.")
         .define(CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS, ConfigDef.Type.LIST, List.of("IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID"),

--- a/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
+++ b/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
@@ -35,6 +35,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
     protected static final String CFG_BUFFER_INITIAL_CAPACITY = "buffer_initial_capacity";
     protected static final String CFG_FIND_COLUMNS_IN_METADATA = "find_columns_in_metadata";
     protected static final String CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS = "exclude_ingest_additional_fields";
+    protected static final String CFG_PROCESS_MULTIPLE_TABLES = "process_multiples_tables";
 
     /*
      * For some use cases we need to load all data again, each time. So we have two
@@ -110,7 +111,10 @@ public class SnowflakeSinkConnector extends SinkConnector {
                 "Define whether to retrieve column names from the metadata or by querying the information schema.")
         .define(CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS, ConfigDef.Type.LIST, List.of("IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID"),
                 ConfigDef.Importance.HIGH,
-                "Defines which fields from the ingest table should be disregarded in the final table.");
+                "Defines which fields from the ingest table should be disregarded in the final table.")
+        .define(CFG_PROCESS_MULTIPLE_TABLES, ConfigDef.Type.BOOLEAN, Boolean.FALSE,
+                ConfigDef.Importance.HIGH,
+                "Determine whether to process multiple tables.");
 
     private Map<String, String> props;
 

--- a/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
+++ b/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
@@ -106,7 +106,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
         .define(CFG_BUFFER_INITIAL_CAPACITY, ConfigDef.Type.INT, 1000000,
                 ConfigDef.Importance.HIGH,
                 "The initial buffer capacity.")
-        .define(CFG_FIND_COLUMNS_IN_METADATA, ConfigDef.Type.BOOLEAN, Boolean.TRUE,
+        .define(CFG_FIND_COLUMNS_IN_METADATA, ConfigDef.Type.BOOLEAN, Boolean.FALSE,
                 ConfigDef.Importance.HIGH,
                 "Define whether to retrieve column names from the metadata or by querying the information schema.")
         .define(CFG_EXCLUDE_INGEST_ADDITIONAL_FIELDS, ConfigDef.Type.LIST, List.of("IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID"),

--- a/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
+++ b/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkConnector.java
@@ -38,6 +38,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
     protected static final String CFG_PROCESS_MULTIPLE_TABLES = "process_multiples_tables";
     protected static final String CFG_MUST_PROCESS_READ_ONLY_MESSAGES = "must_process_read_only_messages";
     protected static final String CFG_TABLES_FIELDS = "tables_fields";
+    protected static final String COPY_ONLY = "copy_only";
 
     /*
      * For some use cases we need to load all data again, each time. So we have two
@@ -122,7 +123,10 @@ public class SnowflakeSinkConnector extends SinkConnector {
                 "Determines whether to process read-only messages.")
         .define(CFG_TABLES_FIELDS, ConfigDef.Type.STRING, null,
                 ConfigDef.Importance.HIGH,
-                "Defines the names of the fields and tables to be processed, disabling column lookup in the database. Format: table1-field1,fieldX|table2-field1,fieldX.");
+                "Defines the names of the fields and tables to be processed, disabling column lookup in the database. Format: table1-field1,fieldX|table2-field1,fieldX.")
+        .define(COPY_ONLY, ConfigDef.Type.BOOLEAN, false,
+                ConfigDef.Importance.HIGH,
+            "If true, we will only copy the data to snowflake, without inserting it into the final table.");
 
     private Map<String, String> props;
 

--- a/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkTask.java
+++ b/src/main/java/br/com/datastreambrasil/v3/SnowflakeSinkTask.java
@@ -11,6 +11,8 @@ import java.util.Map;
 
 public class SnowflakeSinkTask extends SinkTask {
 
+    private static final String PROFILE_TYPE = "cdc_schema";
+
     private AbstractProcessor processor;
 
     @Override
@@ -21,13 +23,11 @@ public class SnowflakeSinkTask extends SinkTask {
     @Override
     public void start(Map<String, String> map) {
         AbstractConfig config = new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, map);
-        
-        switch (config.getString(SnowflakeSinkConnector.CFG_PROFILE)) {
-            case "cdc_schema":
-                processor = new CdcDbzSchemaProcessor();
-                break;
-            default:
-                throw new RuntimeException("Unknown profile: " + config.getString(SnowflakeSinkConnector.CFG_PROFILE));
+
+        if (PROFILE_TYPE.equalsIgnoreCase(config.getString(SnowflakeSinkConnector.CFG_PROFILE))) {
+            processor = new CdcDbzSchemaProcessor();
+        } else {
+            throw new RuntimeException("Unknown profile: " + config.getString(SnowflakeSinkConnector.CFG_PROFILE));
         }
 
         processor.start(config);

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorColumnLoadingTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorColumnLoadingTest.java
@@ -154,7 +154,7 @@ class AbstractProcessorColumnLoadingTest {
     // ── preloadAllTableColumns ────────────────────────────────────────────────
 
     @Test
-    void preloadAllTableColumns_populatesMapsAndKnownIngestTablesForSingleTable() throws SQLException {
+    void preloadAllTableColumns_populatesMapsWithoutPopulatingKnownIngestTables() throws SQLException {
         var p = processor("MY_SCHEMA");
         var stmt = mock(Statement.class);
         var rs = rsFromRows(List.of(
@@ -170,8 +170,8 @@ class AbstractProcessorColumnLoadingTest {
                 "columnsIngestTable should reflect all columns for the ingest table");
         assertEquals(List.of("ID", "NAME"), p.columnsFinalTable.get("MY_TABLE"),
                 "columnsFinalTable should use the base table name (without _INGEST suffix)");
-        assertTrue(p.knownIngestTables.contains("MY_TABLE_INGEST"),
-                "knownIngestTables should include the ingest table name");
+        assertTrue(p.knownIngestTables.isEmpty(),
+                "preloadAllTableColumns must not populate knownIngestTables; only topics in processing do");
     }
 
     @Test
@@ -193,7 +193,8 @@ class AbstractProcessorColumnLoadingTest {
         assertEquals(List.of("ID", "VALUE"), p.columnsFinalTable.get("TABLE_A"));
         assertEquals(List.of("CODE", "DESCRIPTION"), p.columnsIngestTable.get("TABLE_B_INGEST"));
         assertEquals(List.of("CODE", "DESCRIPTION"), p.columnsFinalTable.get("TABLE_B"));
-        assertTrue(p.knownIngestTables.containsAll(List.of("TABLE_A_INGEST", "TABLE_B_INGEST")));
+        assertTrue(p.knownIngestTables.isEmpty(),
+                "preloadAllTableColumns must not populate knownIngestTables; only topics in processing do");
     }
 
     @Test

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorColumnLoadingTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorColumnLoadingTest.java
@@ -1,0 +1,285 @@
+package br.com.datastreambrasil.v3;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AbstractProcessorColumnLoadingTest {
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private CdcDbzSchemaProcessor processor(String schema) {
+        var p = new CdcDbzSchemaProcessor();
+        p.connection = mock(Connection.class);
+        p.schemaName = schema;
+        p.tableName = "MY_TABLE";
+        p.ignoreColumns = new ArrayList<>();
+        p.excludeIngestAdditionalFields = new ArrayList<>();
+        return p;
+    }
+
+    /** ResultSet that iterates over a list of column names (COLUMN_NAME only). */
+    private ResultSet rsFromColumns(List<String> cols) throws SQLException {
+        var rs = mock(ResultSet.class);
+        var idx = new int[]{-1};
+        when(rs.next()).thenAnswer(a -> ++idx[0] < cols.size());
+        when(rs.getString("COLUMN_NAME")).thenAnswer(a -> cols.get(idx[0]));
+        return rs;
+    }
+
+    /** ResultSet that iterates over [TABLE_NAME, COLUMN_NAME] pairs. */
+    private ResultSet rsFromRows(List<String[]> rows) throws SQLException {
+        var rs = mock(ResultSet.class);
+        var idx = new int[]{-1};
+        when(rs.next()).thenAnswer(a -> ++idx[0] < rows.size());
+        when(rs.getString("TABLE_NAME")).thenAnswer(a -> rows.get(idx[0])[0]);
+        when(rs.getString("COLUMN_NAME")).thenAnswer(a -> rows.get(idx[0])[1]);
+        return rs;
+    }
+
+    private AbstractConfig configWithExcludeFields(List<String> excludeFields) {
+        return new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
+                "schema", "MY_SCHEMA",
+                "table", "MY_TABLE",
+                "stage", "MY_STAGE",
+                "exclude_ingest_additional_fields", String.join(",", excludeFields)
+        ));
+    }
+
+    private AbstractConfig defaultConfig() {
+        return new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
+                "schema", "MY_SCHEMA",
+                "table", "MY_TABLE",
+                "stage", "MY_STAGE"
+        ));
+    }
+
+    // ── prepareColumnsFromMetadata ────────────────────────────────────────────
+
+    @Test
+    void prepareColumnsFromMetadata_populatesBothMapsAndKnownIngestTables() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        var cols = List.of("ID", "NAME", "CREATED_AT");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rs = rsFromColumns(cols);
+        when(p.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(isNull(), eq("MY_SCHEMA"), eq("MY_TABLE"), isNull())).thenReturn(rs);
+
+        p.prepareColumnsFromMetadata("MY_TABLE", configWithExcludeFields(List.of()));
+
+        assertEquals(cols, p.columnsFinalTable.get("MY_TABLE"),
+                "columnsFinalTable should contain exactly the metadata columns");
+        assertTrue(p.columnsIngestTable.get("MY_TABLE_INGEST").containsAll(cols),
+                "columnsIngestTable should include all metadata columns");
+        assertTrue(p.knownIngestTables.contains("MY_TABLE_INGEST"),
+                "knownIngestTables should be updated with the ingest table name");
+    }
+
+    @Test
+    void prepareColumnsFromMetadata_ignoreColumnsRemovedFromBothMaps() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        p.ignoreColumns.add("AUDIT_COL");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rs = rsFromColumns(List.of("ID", "NAME", "AUDIT_COL"));
+        when(p.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(isNull(), eq("MY_SCHEMA"), eq("MY_TABLE"), isNull())).thenReturn(rs);
+
+        p.prepareColumnsFromMetadata("MY_TABLE", configWithExcludeFields(List.of()));
+
+        assertFalse(p.columnsFinalTable.get("MY_TABLE").contains("AUDIT_COL"),
+                "ignoreColumns should be removed from final table");
+        assertFalse(p.columnsIngestTable.get("MY_TABLE_INGEST").contains("AUDIT_COL"),
+                "ignoreColumns should be removed from ingest table");
+        assertTrue(p.columnsFinalTable.get("MY_TABLE").containsAll(List.of("ID", "NAME")));
+    }
+
+    @Test
+    void prepareColumnsFromMetadata_excludeIngestAdditionalFieldsAddedOnlyToIngestTable() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rs = rsFromColumns(List.of("ID", "NAME"));
+        when(p.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(isNull(), eq("MY_SCHEMA"), eq("MY_TABLE"), isNull())).thenReturn(rs);
+
+        p.prepareColumnsFromMetadata("MY_TABLE", configWithExcludeFields(List.of("IH_TOPIC", "IH_OFFSET")));
+
+        var finalCols = p.columnsFinalTable.get("MY_TABLE");
+        var ingestCols = p.columnsIngestTable.get("MY_TABLE_INGEST");
+        assertFalse(finalCols.contains("IH_TOPIC"), "excludeIngestAdditionalFields must not appear in final table");
+        assertFalse(finalCols.contains("IH_OFFSET"), "excludeIngestAdditionalFields must not appear in final table");
+        assertTrue(ingestCols.contains("IH_TOPIC"), "excludeIngestAdditionalFields must be present in ingest table");
+        assertTrue(ingestCols.contains("IH_OFFSET"), "excludeIngestAdditionalFields must be present in ingest table");
+    }
+
+    @Test
+    void prepareColumnsFromMetadata_emptyMetadataResultThrowsRuntimeException() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rs = rsFromColumns(List.of());
+        when(p.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(isNull(), eq("MY_SCHEMA"), eq("MY_TABLE"), isNull())).thenReturn(rs);
+
+        assertThrows(RuntimeException.class,
+                () -> p.prepareColumnsFromMetadata("MY_TABLE", defaultConfig()));
+    }
+
+    @Test
+    void prepareColumnsFromMetadata_sqlExceptionWrappedInRuntimeException() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        when(p.connection.getMetaData()).thenThrow(new SQLException("connection failed"));
+
+        assertThrows(RuntimeException.class,
+                () -> p.prepareColumnsFromMetadata("MY_TABLE", defaultConfig()));
+    }
+
+    // ── preloadAllTableColumns ────────────────────────────────────────────────
+
+    @Test
+    void preloadAllTableColumns_populatesMapsAndKnownIngestTablesForSingleTable() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        var stmt = mock(Statement.class);
+        var rs = rsFromRows(List.of(
+                new String[]{"MY_TABLE_INGEST", "ID"},
+                new String[]{"MY_TABLE_INGEST", "NAME"}
+        ));
+        when(p.connection.createStatement()).thenReturn(stmt);
+        when(stmt.executeQuery(any())).thenReturn(rs);
+
+        p.preloadAllTableColumns();
+
+        assertEquals(List.of("ID", "NAME"), p.columnsIngestTable.get("MY_TABLE_INGEST"),
+                "columnsIngestTable should reflect all columns for the ingest table");
+        assertEquals(List.of("ID", "NAME"), p.columnsFinalTable.get("MY_TABLE"),
+                "columnsFinalTable should use the base table name (without _INGEST suffix)");
+        assertTrue(p.knownIngestTables.contains("MY_TABLE_INGEST"),
+                "knownIngestTables should include the ingest table name");
+    }
+
+    @Test
+    void preloadAllTableColumns_multipleTables_eachTablePopulatedIndependently() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        var stmt = mock(Statement.class);
+        var rs = rsFromRows(List.of(
+                new String[]{"TABLE_A_INGEST", "ID"},
+                new String[]{"TABLE_A_INGEST", "VALUE"},
+                new String[]{"TABLE_B_INGEST", "CODE"},
+                new String[]{"TABLE_B_INGEST", "DESCRIPTION"}
+        ));
+        when(p.connection.createStatement()).thenReturn(stmt);
+        when(stmt.executeQuery(any())).thenReturn(rs);
+
+        p.preloadAllTableColumns();
+
+        assertEquals(List.of("ID", "VALUE"), p.columnsIngestTable.get("TABLE_A_INGEST"));
+        assertEquals(List.of("ID", "VALUE"), p.columnsFinalTable.get("TABLE_A"));
+        assertEquals(List.of("CODE", "DESCRIPTION"), p.columnsIngestTable.get("TABLE_B_INGEST"));
+        assertEquals(List.of("CODE", "DESCRIPTION"), p.columnsFinalTable.get("TABLE_B"));
+        assertTrue(p.knownIngestTables.containsAll(List.of("TABLE_A_INGEST", "TABLE_B_INGEST")));
+    }
+
+    @Test
+    void preloadAllTableColumns_ignoreColumnsRemovedFromBothMaps() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        p.ignoreColumns.add("AUDIT_COL");
+        var stmt = mock(Statement.class);
+        var rs = rsFromRows(List.of(
+                new String[]{"MY_TABLE_INGEST", "ID"},
+                new String[]{"MY_TABLE_INGEST", "AUDIT_COL"},
+                new String[]{"MY_TABLE_INGEST", "NAME"}
+        ));
+        when(p.connection.createStatement()).thenReturn(stmt);
+        when(stmt.executeQuery(any())).thenReturn(rs);
+
+        p.preloadAllTableColumns();
+
+        assertFalse(p.columnsIngestTable.get("MY_TABLE_INGEST").contains("AUDIT_COL"),
+                "ignoreColumns should be removed from ingest table");
+        assertFalse(p.columnsFinalTable.get("MY_TABLE").contains("AUDIT_COL"),
+                "ignoreColumns should be removed from final table");
+        assertTrue(p.columnsIngestTable.get("MY_TABLE_INGEST").containsAll(List.of("ID", "NAME")));
+    }
+
+    @Test
+    void preloadAllTableColumns_excludeIngestAdditionalFieldsRemovedFromFinalTableOnly() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        p.excludeIngestAdditionalFields = new ArrayList<>(List.of("IH_TOPIC", "IH_OFFSET"));
+        var stmt = mock(Statement.class);
+        var rs = rsFromRows(List.of(
+                new String[]{"MY_TABLE_INGEST", "ID"},
+                new String[]{"MY_TABLE_INGEST", "IH_TOPIC"},
+                new String[]{"MY_TABLE_INGEST", "IH_OFFSET"}
+        ));
+        when(p.connection.createStatement()).thenReturn(stmt);
+        when(stmt.executeQuery(any())).thenReturn(rs);
+
+        p.preloadAllTableColumns();
+
+        var ingestCols = p.columnsIngestTable.get("MY_TABLE_INGEST");
+        var finalCols = p.columnsFinalTable.get("MY_TABLE");
+        assertTrue(ingestCols.containsAll(List.of("IH_TOPIC", "IH_OFFSET")),
+                "excludeIngestAdditionalFields must remain in ingest table");
+        assertFalse(finalCols.contains("IH_TOPIC"),
+                "excludeIngestAdditionalFields must be excluded from final table");
+        assertFalse(finalCols.contains("IH_OFFSET"),
+                "excludeIngestAdditionalFields must be excluded from final table");
+        assertTrue(finalCols.contains("ID"), "Non-excluded columns should remain in final table");
+    }
+
+    @Test
+    void preloadAllTableColumns_excludeIngestAdditionalFieldsCaseInsensitive() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        p.excludeIngestAdditionalFields = new ArrayList<>(List.of("IH_TOPIC"));
+        var stmt = mock(Statement.class);
+        // Ingest table column in lowercase while excludeIngestAdditionalFields is uppercase
+        var rs = rsFromRows(List.of(
+                new String[]{"MY_TABLE_INGEST", "ID"},
+                new String[]{"MY_TABLE_INGEST", "ih_topic"}
+        ));
+        when(p.connection.createStatement()).thenReturn(stmt);
+        when(stmt.executeQuery(any())).thenReturn(rs);
+
+        p.preloadAllTableColumns();
+
+        assertFalse(p.columnsFinalTable.get("MY_TABLE").contains("ih_topic"),
+                "Exclusion comparison should be case-insensitive");
+        assertTrue(p.columnsIngestTable.get("MY_TABLE_INGEST").contains("ih_topic"),
+                "Ingest table should still retain the column regardless of case");
+    }
+
+    @Test
+    void preloadAllTableColumns_emptyResultThrowsRuntimeException() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        var stmt = mock(Statement.class);
+        var rs = rsFromRows(List.of());
+        when(p.connection.createStatement()).thenReturn(stmt);
+        when(stmt.executeQuery(any())).thenReturn(rs);
+
+        assertThrows(RuntimeException.class, p::preloadAllTableColumns);
+    }
+
+    @Test
+    void preloadAllTableColumns_sqlExceptionWrappedInRuntimeException() throws SQLException {
+        var p = processor("MY_SCHEMA");
+        when(p.connection.createStatement()).thenThrow(new SQLException("db down"));
+
+        assertThrows(RuntimeException.class, p::preloadAllTableColumns);
+    }
+}

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorColumnLoadingTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorColumnLoadingTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -281,5 +282,64 @@ class AbstractProcessorColumnLoadingTest {
         when(p.connection.createStatement()).thenThrow(new SQLException("db down"));
 
         assertThrows(RuntimeException.class, p::preloadAllTableColumns);
+    }
+
+    // ── loadColumnsFromConfig ─────────────────────────────────────────────────
+
+    @Test
+    void loadColumnsFromConfig_singleTable_populatesBothMapsAndKnownIngestTables() {
+        var p = processor("MY_SCHEMA");
+
+        p.loadColumnsFromConfig("MY_TABLE-ID,NAME,CREATED_AT");
+
+        assertEquals(List.of("ID", "NAME", "CREATED_AT"), p.columnsIngestTable.get("MY_TABLE_INGEST"));
+        assertEquals(List.of("ID", "NAME", "CREATED_AT"), p.columnsFinalTable.get("MY_TABLE"));
+        assertTrue(p.knownIngestTables.contains("MY_TABLE_INGEST"));
+    }
+
+    @Test
+    void loadColumnsFromConfig_multipleTables_eachTablePopulatedIndependently() {
+        var p = processor("MY_SCHEMA");
+
+        p.loadColumnsFromConfig("TABLE_A-ID,VALUE|TABLE_B-CODE,DESCRIPTION");
+
+        assertEquals(List.of("ID", "VALUE"), p.columnsIngestTable.get("TABLE_A_INGEST"));
+        assertEquals(List.of("ID", "VALUE"), p.columnsFinalTable.get("TABLE_A"));
+        assertEquals(List.of("CODE", "DESCRIPTION"), p.columnsIngestTable.get("TABLE_B_INGEST"));
+        assertEquals(List.of("CODE", "DESCRIPTION"), p.columnsFinalTable.get("TABLE_B"));
+        assertTrue(p.knownIngestTables.containsAll(List.of("TABLE_A_INGEST", "TABLE_B_INGEST")));
+    }
+
+    @Test
+    void loadColumnsFromConfig_ignoreColumnsRemovedFromBothMaps() {
+        var p = processor("MY_SCHEMA");
+        p.ignoreColumns.add("AUDIT_COL");
+
+        p.loadColumnsFromConfig("MY_TABLE-ID,NAME,AUDIT_COL");
+
+        assertFalse(p.columnsIngestTable.get("MY_TABLE_INGEST").contains("AUDIT_COL"),
+                "ignoreColumns should be removed from ingest table");
+        assertFalse(p.columnsFinalTable.get("MY_TABLE").contains("AUDIT_COL"),
+                "ignoreColumns should be removed from final table");
+        assertTrue(p.columnsIngestTable.get("MY_TABLE_INGEST").containsAll(List.of("ID", "NAME")));
+    }
+
+    @Test
+    void loadColumnsFromConfig_tableNameConvertedToUpperCase() {
+        var p = processor("MY_SCHEMA");
+
+        p.loadColumnsFromConfig("my_table-ID,NAME");
+
+        assertTrue(p.knownIngestTables.contains("MY_TABLE_INGEST"),
+                "Table name should be uppercased");
+        assertNotNull(p.columnsFinalTable.get("MY_TABLE"));
+    }
+
+    @Test
+    void loadColumnsFromConfig_invalidFormatThrowsRuntimeException() {
+        var p = processor("MY_SCHEMA");
+
+        assertThrows(RuntimeException.class,
+                () -> p.loadColumnsFromConfig("INVALID_ENTRY_WITHOUT_DASH"));
     }
 }

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
@@ -3,123 +3,17 @@ package br.com.datastreambrasil.v3;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests AbstractProcessor's lazy column loading via both the JDBC metadata API
  * and the INFORMATION_SCHEMA query path.
  */
 class AbstractProcessorInformationSchemaTest {
-
-    @Test
-    void testUsesMetadataApiNotStatement() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        processor.findInColumnsMetadata = true;
-        var dbMeta = mock(DatabaseMetaData.class);
-        var rsIngest = buildResultSet(List.of("COL1", "IH_TOPIC"));
-        when(processor.connection.getMetaData()).thenReturn(dbMeta);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
-
-        processor.ensureColumnsForTable("MY_TABLE");
-
-        verify(processor.connection, atLeastOnce()).getMetaData();
-        verify(processor.connection, never()).createStatement();
-        verify(processor.connection, never()).prepareStatement(anyString());
-    }
-
-    @Test
-    void testUsesStatementWhenFindColumnsMetadataIsFalse() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        processor.findInColumnsMetadata = false;
-        mockStatementForColumns(processor, List.of("COL1", "IH_TOPIC"));
-
-        processor.ensureColumnsForTable("MY_TABLE");
-
-        verify(processor.connection, atLeastOnce()).createStatement();
-        verify(processor.connection, never()).getMetaData();
-    }
-
-    @Test
-    void testColumnsLoadedOnlyOnceForSameTable() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        mockStatementForColumns(processor, List.of("COL1", "IH_TOPIC"));
-
-        processor.ensureColumnsForTable("MY_TABLE");
-        processor.ensureColumnsForTable("MY_TABLE"); // second call — must hit cache
-
-        // createStatement called only once: only on the first invocation
-        verify(processor.connection, times(1)).createStatement();
-    }
-
-    @Test
-    void testColumnsIngestTableAndFinalTablePopulated() throws Exception {
-        var ingestColumns = List.of("COL1", "COL2", "IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        mockStatementForColumns(processor, ingestColumns);
-
-        processor.ensureColumnsForTable("MY_TABLE");
-
-        assertEquals(ingestColumns, processor.columnsIngestTable.get("MY_TABLE"));
-        // finalTable is derived from ingestTable by filtering out excludeIngestAdditionalFields
-        assertEquals(List.of("COL1", "COL2"), processor.columnsFinalTable.get("MY_TABLE"));
-    }
-
-    @Test
-    void testThrowsExceptionWhenNoColumnsFound() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        mockStatementForColumns(processor, List.of());
-
-        assertThrows(RuntimeException.class, () -> processor.ensureColumnsForTable("MY_TABLE"));
-    }
-
-    @Test
-    void testIgnoreColumnsAreFiltered() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        processor.ignoreColumns.add("COL2");
-        mockStatementForColumns(processor, List.of("COL1", "COL2", "COL3"));
-
-        processor.ensureColumnsForTable("MY_TABLE");
-
-        assertEquals(List.of("COL1", "COL3"), processor.columnsIngestTable.get("MY_TABLE"));
-    }
-
-    @Test
-    void testPreloadAllIngestTableColumnsPopulatesCache() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "ANY_TABLE");
-        var rows = List.of(
-                new String[]{"TABLE_A_INGEST", "COL1"},
-                new String[]{"TABLE_A_INGEST", "COL2"},
-                new String[]{"TABLE_A_INGEST", "IH_TOPIC"},
-                new String[]{"TABLE_B_INGEST", "COL3"},
-                new String[]{"TABLE_B_INGEST", "IH_OP"}
-        );
-        mockBulkStatementForColumns(processor, rows);
-
-        processor.preloadAllIngestTableColumns();
-
-        assertEquals(List.of("COL1", "COL2", "IH_TOPIC"), processor.columnsIngestTable.get("TABLE_A"));
-        assertEquals(List.of("COL1", "COL2"), processor.columnsFinalTable.get("TABLE_A"));
-        assertEquals(List.of("COL3", "IH_OP"), processor.columnsIngestTable.get("TABLE_B"));
-        assertEquals(List.of("COL3"), processor.columnsFinalTable.get("TABLE_B"));
-    }
-
-    @Test
-    void testPreloadAllIngestTableColumnsEmptySchema() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "ANY_TABLE");
-        mockBulkStatementForColumns(processor, List.of());
-
-        processor.preloadAllIngestTableColumns();
-
-        assertTrue(processor.columnsIngestTable.isEmpty());
-    }
 
     @Test
     void testKnownIngestTablesPopulatedOnGetOrCreateBuffer() {
@@ -132,29 +26,6 @@ class AbstractProcessorInformationSchemaTest {
                 "knownIngestTables should contain MY_TABLE_INGEST after buffer creation");
     }
 
-    @Test
-    void testExtractTableNameFromTopicWithDot() {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        processor.processMultiTables = true;
-        assertEquals("tabelaX", processor.extractTableNameFromTopic("compras.loja-b.tabelaX"));
-        assertEquals("tabelaZ", processor.extractTableNameFromTopic("compras.loja-c.tabelaZ"));
-    }
-
-    @Test
-    void testExtractTableNameFromTopicWithoutDotFallsBackToTableName() {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        assertEquals("MY_TABLE", processor.extractTableNameFromTopic("no_dot_topic"));
-        assertEquals("MY_TABLE", processor.extractTableNameFromTopic(null));
-    }
-
-    @Test
-    void testExtractTableNameFromTopicWithDotButSingleTableMode() {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        processor.processMultiTables = false;
-        assertEquals("MY_TABLE", processor.extractTableNameFromTopic("compras.loja-b.tabelaX"),
-                "Single-table mode must ignore topic and always use tableName");
-    }
-
     private CdcDbzSchemaProcessor createProcessor(String schemaName, String tableBaseName) {
         var processor = new CdcDbzSchemaProcessor();
         processor.connection = mock(Connection.class);
@@ -163,41 +34,5 @@ class AbstractProcessorInformationSchemaTest {
         processor.ignoreColumns = new ArrayList<>();
         processor.excludeIngestAdditionalFields = List.of("IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
         return processor;
-    }
-
-    private Statement mockBulkStatementForColumns(CdcDbzSchemaProcessor processor, List<String[]> rows) throws Exception {
-        var stmtMock = mock(Statement.class);
-        var rsMock = mock(ResultSet.class);
-        var idx = new int[]{-1};
-        when(rsMock.next()).thenAnswer(a -> {
-            idx[0]++;
-            return idx[0] < rows.size();
-        });
-        when(rsMock.getString("TABLE_NAME")).thenAnswer(a -> rows.get(idx[0])[0]);
-        when(rsMock.getString("COLUMN_NAME")).thenAnswer(a -> rows.get(idx[0])[1]);
-        when(processor.connection.createStatement()).thenReturn(stmtMock);
-        when(stmtMock.executeQuery(any())).thenReturn(rsMock);
-        return stmtMock;
-    }
-
-    private Statement mockStatementForColumns(CdcDbzSchemaProcessor processor, List<String> columns) throws Exception {
-        var stmtMock = mock(Statement.class);
-        var rsMock = buildResultSet(columns);
-        when(processor.connection.createStatement()).thenReturn(stmtMock);
-        when(stmtMock.executeQuery(any())).thenReturn(rsMock);
-        return stmtMock;
-    }
-
-    private ResultSet buildResultSet(List<String> columns) throws Exception {
-        var rs = mock(ResultSet.class);
-        var idx = new int[]{-1};
-        when(rs.next()).thenAnswer(a -> {
-            idx[0]++;
-            return idx[0] < columns.size();
-        });
-        if (!columns.isEmpty()) {
-            when(rs.getString("COLUMN_NAME")).thenAnswer(a -> columns.get(idx[0]));
-        }
-        return rs;
     }
 }

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
@@ -21,10 +21,8 @@ class AbstractProcessorInformationSchemaTest {
     void testUsesMetadataApiNotStatement() throws Exception {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
         var dbMeta = mock(DatabaseMetaData.class);
-        var rsTable = buildResultSet(List.of("COL1"));
         var rsIngest = buildResultSet(List.of("COL1", "IH_TOPIC"));
         when(processor.connection.getMetaData()).thenReturn(dbMeta);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
         when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
 
         processor.ensureColumnsForTable("MY_TABLE");
@@ -38,35 +36,31 @@ class AbstractProcessorInformationSchemaTest {
     void testColumnsLoadedOnlyOnceForSameTable() throws Exception {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
         var dbMeta = mock(DatabaseMetaData.class);
-        var rsTable = buildResultSet(List.of("COL1"));
         var rsIngest = buildResultSet(List.of("COL1", "IH_TOPIC"));
         when(processor.connection.getMetaData()).thenReturn(dbMeta);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
         when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
 
         processor.ensureColumnsForTable("MY_TABLE");
         processor.ensureColumnsForTable("MY_TABLE"); // second call — must hit cache
 
-        // Each table triggers exactly 2 metadata calls (table + ingest), only on the first invocation
-        verify(dbMeta, times(2)).getColumns(any(), any(), any(), any());
+        // Only one metadata call per table (only the ingest table is queried), only on the first invocation
+        verify(dbMeta, times(1)).getColumns(any(), any(), any(), any());
     }
 
     @Test
     void testColumnsIngestTableAndFinalTablePopulated() throws Exception {
         var ingestColumns = List.of("COL1", "COL2", "IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
-        var finalColumns = List.of("COL1", "COL2");
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
         var dbMeta = mock(DatabaseMetaData.class);
         var rsIngest = buildResultSet(ingestColumns);
-        var rsTable = buildResultSet(finalColumns);
         when(processor.connection.getMetaData()).thenReturn(dbMeta);
         when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
 
         processor.ensureColumnsForTable("MY_TABLE");
 
         assertEquals(ingestColumns, processor.columnsIngestTable.get("MY_TABLE"));
-        assertEquals(finalColumns, processor.columnsFinalTable.get("MY_TABLE"));
+        // finalTable is derived from ingestTable by filtering out excludeIngestAdditionalFields
+        assertEquals(List.of("COL1", "COL2"), processor.columnsFinalTable.get("MY_TABLE"));
     }
 
     @Test
@@ -86,10 +80,8 @@ class AbstractProcessorInformationSchemaTest {
         processor.ignoreColumns.add("COL2");
         var dbMeta = mock(DatabaseMetaData.class);
         var rsIngest = buildResultSet(List.of("COL1", "COL2", "COL3"));
-        var rsTable = buildResultSet(List.of("COL1", "COL3"));
         when(processor.connection.getMetaData()).thenReturn(dbMeta);
         when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
 
         processor.ensureColumnsForTable("MY_TABLE");
 
@@ -127,6 +119,7 @@ class AbstractProcessorInformationSchemaTest {
         processor.schemaName = schemaName;
         processor.tableName = tableBaseName;
         processor.ignoreColumns = new ArrayList<>();
+        processor.excludeIngestAdditionalFields = List.of("IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
         return processor;
     }
 

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
@@ -135,6 +135,7 @@ class AbstractProcessorInformationSchemaTest {
     @Test
     void testExtractTableNameFromTopicWithDot() {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        processor.processMultiTables = true;
         assertEquals("tabelaX", processor.extractTableNameFromTopic("compras.loja-b.tabelaX"));
         assertEquals("tabelaZ", processor.extractTableNameFromTopic("compras.loja-c.tabelaZ"));
     }
@@ -144,6 +145,14 @@ class AbstractProcessorInformationSchemaTest {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
         assertEquals("MY_TABLE", processor.extractTableNameFromTopic("no_dot_topic"));
         assertEquals("MY_TABLE", processor.extractTableNameFromTopic(null));
+    }
+
+    @Test
+    void testExtractTableNameFromTopicWithDotButSingleTableMode() {
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        processor.processMultiTables = false;
+        assertEquals("MY_TABLE", processor.extractTableNameFromTopic("compras.loja-b.tabelaX"),
+                "Single-table mode must ignore topic and always use tableName");
     }
 
     private CdcDbzSchemaProcessor createProcessor(String schemaName, String tableBaseName) {

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,13 +14,15 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests AbstractProcessor's lazy column loading via the JDBC metadata API.
+ * Tests AbstractProcessor's lazy column loading via both the JDBC metadata API
+ * and the INFORMATION_SCHEMA query path.
  */
 class AbstractProcessorInformationSchemaTest {
 
     @Test
     void testUsesMetadataApiNotStatement() throws Exception {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        processor.findInColumnsMetadata = true;
         var dbMeta = mock(DatabaseMetaData.class);
         var rsIngest = buildResultSet(List.of("COL1", "IH_TOPIC"));
         when(processor.connection.getMetaData()).thenReturn(dbMeta);
@@ -33,28 +36,34 @@ class AbstractProcessorInformationSchemaTest {
     }
 
     @Test
+    void testUsesStatementWhenFindColumnsMetadataIsFalse() throws Exception {
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        // findInColumnsMetadata defaults to false
+        mockStatementForColumns(processor, List.of("COL1", "IH_TOPIC"));
+
+        processor.ensureColumnsForTable("MY_TABLE");
+
+        verify(processor.connection, atLeastOnce()).createStatement();
+        verify(processor.connection, never()).getMetaData();
+    }
+
+    @Test
     void testColumnsLoadedOnlyOnceForSameTable() throws Exception {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        var dbMeta = mock(DatabaseMetaData.class);
-        var rsIngest = buildResultSet(List.of("COL1", "IH_TOPIC"));
-        when(processor.connection.getMetaData()).thenReturn(dbMeta);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
+        mockStatementForColumns(processor, List.of("COL1", "IH_TOPIC"));
 
         processor.ensureColumnsForTable("MY_TABLE");
         processor.ensureColumnsForTable("MY_TABLE"); // second call — must hit cache
 
-        // Only one metadata call per table (only the ingest table is queried), only on the first invocation
-        verify(dbMeta, times(1)).getColumns(any(), any(), any(), any());
+        // createStatement called only once: only on the first invocation
+        verify(processor.connection, times(1)).createStatement();
     }
 
     @Test
     void testColumnsIngestTableAndFinalTablePopulated() throws Exception {
         var ingestColumns = List.of("COL1", "COL2", "IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        var dbMeta = mock(DatabaseMetaData.class);
-        var rsIngest = buildResultSet(ingestColumns);
-        when(processor.connection.getMetaData()).thenReturn(dbMeta);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
+        mockStatementForColumns(processor, ingestColumns);
 
         processor.ensureColumnsForTable("MY_TABLE");
 
@@ -66,10 +75,7 @@ class AbstractProcessorInformationSchemaTest {
     @Test
     void testThrowsExceptionWhenNoColumnsFound() throws Exception {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        var dbMeta = mock(DatabaseMetaData.class);
-        var rsEmpty = buildResultSet(List.of());
-        when(processor.connection.getMetaData()).thenReturn(dbMeta);
-        when(dbMeta.getColumns(any(), any(), any(), any())).thenReturn(rsEmpty);
+        mockStatementForColumns(processor, List.of());
 
         assertThrows(RuntimeException.class, () -> processor.ensureColumnsForTable("MY_TABLE"));
     }
@@ -78,10 +84,7 @@ class AbstractProcessorInformationSchemaTest {
     void testIgnoreColumnsAreFiltered() throws Exception {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
         processor.ignoreColumns.add("COL2");
-        var dbMeta = mock(DatabaseMetaData.class);
-        var rsIngest = buildResultSet(List.of("COL1", "COL2", "COL3"));
-        when(processor.connection.getMetaData()).thenReturn(dbMeta);
-        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
+        mockStatementForColumns(processor, List.of("COL1", "COL2", "COL3"));
 
         processor.ensureColumnsForTable("MY_TABLE");
 
@@ -121,6 +124,14 @@ class AbstractProcessorInformationSchemaTest {
         processor.ignoreColumns = new ArrayList<>();
         processor.excludeIngestAdditionalFields = List.of("IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
         return processor;
+    }
+
+    private Statement mockStatementForColumns(CdcDbzSchemaProcessor processor, List<String> columns) throws Exception {
+        var stmtMock = mock(Statement.class);
+        var rsMock = buildResultSet(columns);
+        when(processor.connection.createStatement()).thenReturn(stmtMock);
+        when(stmtMock.executeQuery(any())).thenReturn(rsMock);
+        return stmtMock;
     }
 
     private ResultSet buildResultSet(List<String> columns) throws Exception {

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
@@ -38,7 +38,7 @@ class AbstractProcessorInformationSchemaTest {
     @Test
     void testUsesStatementWhenFindColumnsMetadataIsFalse() throws Exception {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
-        // findInColumnsMetadata defaults to false
+        processor.findInColumnsMetadata = false;
         mockStatementForColumns(processor, List.of("COL1", "IH_TOPIC"));
 
         processor.ensureColumnsForTable("MY_TABLE");

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
@@ -92,6 +92,36 @@ class AbstractProcessorInformationSchemaTest {
     }
 
     @Test
+    void testPreloadAllIngestTableColumnsPopulatesCache() throws Exception {
+        var processor = createProcessor("MY_SCHEMA", "ANY_TABLE");
+        var rows = List.of(
+                new String[]{"TABLE_A_INGEST", "COL1"},
+                new String[]{"TABLE_A_INGEST", "COL2"},
+                new String[]{"TABLE_A_INGEST", "IH_TOPIC"},
+                new String[]{"TABLE_B_INGEST", "COL3"},
+                new String[]{"TABLE_B_INGEST", "IH_OP"}
+        );
+        mockBulkStatementForColumns(processor, rows);
+
+        processor.preloadAllIngestTableColumns();
+
+        assertEquals(List.of("COL1", "COL2", "IH_TOPIC"), processor.columnsIngestTable.get("TABLE_A"));
+        assertEquals(List.of("COL1", "COL2"), processor.columnsFinalTable.get("TABLE_A"));
+        assertEquals(List.of("COL3", "IH_OP"), processor.columnsIngestTable.get("TABLE_B"));
+        assertEquals(List.of("COL3"), processor.columnsFinalTable.get("TABLE_B"));
+    }
+
+    @Test
+    void testPreloadAllIngestTableColumnsEmptySchema() throws Exception {
+        var processor = createProcessor("MY_SCHEMA", "ANY_TABLE");
+        mockBulkStatementForColumns(processor, List.of());
+
+        processor.preloadAllIngestTableColumns();
+
+        assertTrue(processor.columnsIngestTable.isEmpty());
+    }
+
+    @Test
     void testKnownIngestTablesPopulatedOnGetOrCreateBuffer() {
         var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
         processor.bufferInitialCapacity = 100;
@@ -124,6 +154,21 @@ class AbstractProcessorInformationSchemaTest {
         processor.ignoreColumns = new ArrayList<>();
         processor.excludeIngestAdditionalFields = List.of("IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
         return processor;
+    }
+
+    private Statement mockBulkStatementForColumns(CdcDbzSchemaProcessor processor, List<String[]> rows) throws Exception {
+        var stmtMock = mock(Statement.class);
+        var rsMock = mock(ResultSet.class);
+        var idx = new int[]{-1};
+        when(rsMock.next()).thenAnswer(a -> {
+            idx[0]++;
+            return idx[0] < rows.size();
+        });
+        when(rsMock.getString("TABLE_NAME")).thenAnswer(a -> rows.get(idx[0])[0]);
+        when(rsMock.getString("COLUMN_NAME")).thenAnswer(a -> rows.get(idx[0])[1]);
+        when(processor.connection.createStatement()).thenReturn(stmtMock);
+        when(stmtMock.executeQuery(any())).thenReturn(rsMock);
+        return stmtMock;
     }
 
     private Statement mockStatementForColumns(CdcDbzSchemaProcessor processor, List<String> columns) throws Exception {

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorInformationSchemaTest.java
@@ -1,103 +1,131 @@
 package br.com.datastreambrasil.v3;
 
-import org.apache.kafka.common.config.AbstractConfig;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Tests AbstractProcessor's lazy column loading via the JDBC metadata API.
+ */
 class AbstractProcessorInformationSchemaTest {
 
     @Test
-    void testUsesStatementNotPreparedStatement() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE_INGEST");
-        var mockStatement = mock(Statement.class);
-        var mockResultSet = buildResultSet(List.of("COL1"));
+    void testUsesMetadataApiNotStatement() throws Exception {
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rsTable = buildResultSet(List.of("COL1"));
+        var rsIngest = buildResultSet(List.of("COL1", "IH_TOPIC"));
+        when(processor.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
 
-        when(processor.connection.createStatement()).thenReturn(mockStatement);
-        when(mockStatement.executeQuery(anyString())).thenReturn(mockResultSet);
+        processor.ensureColumnsForTable("MY_TABLE");
 
-        processor.configMetadataV2(createConfig());
-
-        verify(processor.connection).createStatement();
+        verify(processor.connection, atLeastOnce()).getMetaData();
+        verify(processor.connection, never()).createStatement();
         verify(processor.connection, never()).prepareStatement(anyString());
     }
 
     @Test
-    void testSqlContainsUppercaseSchemaAndTable() throws Exception {
-        var processor = createProcessor("my_schema", "my_table_INGEST");
-        var mockStatement = mock(Statement.class);
-        var mockResultSet = buildResultSet(List.of("COL1"));
+    void testColumnsLoadedOnlyOnceForSameTable() throws Exception {
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rsTable = buildResultSet(List.of("COL1"));
+        var rsIngest = buildResultSet(List.of("COL1", "IH_TOPIC"));
+        when(processor.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
 
-        when(processor.connection.createStatement()).thenReturn(mockStatement);
-        when(mockStatement.executeQuery(anyString())).thenReturn(mockResultSet);
+        processor.ensureColumnsForTable("MY_TABLE");
+        processor.ensureColumnsForTable("MY_TABLE"); // second call — must hit cache
 
-        processor.configMetadataV2(createConfig());
-
-        verify(mockStatement).executeQuery(argThat(sql ->
-                sql.contains("'MY_SCHEMA'") && sql.contains("'MY_TABLE_INGEST'")));
+        // Each table triggers exactly 2 metadata calls (table + ingest), only on the first invocation
+        verify(dbMeta, times(2)).getColumns(any(), any(), any(), any());
     }
 
     @Test
     void testColumnsIngestTableAndFinalTablePopulated() throws Exception {
         var ingestColumns = List.of("COL1", "COL2", "IH_TOPIC", "IH_PARTITION", "IH_OFFSET", "IH_OP", "IH_DATETIME", "IH_BLOCKID");
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE_INGEST");
-        var mockStatement = mock(Statement.class);
-        var mockResultSet = buildResultSet(ingestColumns);
+        var finalColumns = List.of("COL1", "COL2");
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rsIngest = buildResultSet(ingestColumns);
+        var rsTable = buildResultSet(finalColumns);
+        when(processor.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
 
-        when(processor.connection.createStatement()).thenReturn(mockStatement);
-        when(mockStatement.executeQuery(anyString())).thenReturn(mockResultSet);
+        processor.ensureColumnsForTable("MY_TABLE");
 
-        processor.configMetadataV2(createConfig());
-
-        assertEquals(ingestColumns, processor.columnsIngestTable);
-        assertEquals(List.of("COL1", "COL2"), processor.columnsFinalTable);
+        assertEquals(ingestColumns, processor.columnsIngestTable.get("MY_TABLE"));
+        assertEquals(finalColumns, processor.columnsFinalTable.get("MY_TABLE"));
     }
 
     @Test
     void testThrowsExceptionWhenNoColumnsFound() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE_INGEST");
-        var mockStatement = mock(Statement.class);
-        var mockResultSet = buildResultSet(List.of());
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rsEmpty = buildResultSet(List.of());
+        when(processor.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(any(), any(), any(), any())).thenReturn(rsEmpty);
 
-        when(processor.connection.createStatement()).thenReturn(mockStatement);
-        when(mockStatement.executeQuery(anyString())).thenReturn(mockResultSet);
-
-        assertThrows(RuntimeException.class, () -> processor.configMetadataV2(createConfig()));
+        assertThrows(RuntimeException.class, () -> processor.ensureColumnsForTable("MY_TABLE"));
     }
 
     @Test
     void testIgnoreColumnsAreFiltered() throws Exception {
-        var processor = createProcessor("MY_SCHEMA", "MY_TABLE_INGEST");
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
         processor.ignoreColumns.add("COL2");
-        var mockStatement = mock(Statement.class);
-        var mockResultSet = buildResultSet(List.of("COL1", "COL2", "COL3"));
+        var dbMeta = mock(DatabaseMetaData.class);
+        var rsIngest = buildResultSet(List.of("COL1", "COL2", "COL3"));
+        var rsTable = buildResultSet(List.of("COL1", "COL3"));
+        when(processor.connection.getMetaData()).thenReturn(dbMeta);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE_INGEST"), any())).thenReturn(rsIngest);
+        when(dbMeta.getColumns(any(), any(), eq("MY_TABLE"), any())).thenReturn(rsTable);
 
-        when(processor.connection.createStatement()).thenReturn(mockStatement);
-        when(mockStatement.executeQuery(anyString())).thenReturn(mockResultSet);
+        processor.ensureColumnsForTable("MY_TABLE");
 
-        processor.configMetadataV2(createConfig());
-
-        assertEquals(List.of("COL1", "COL3"), processor.columnsIngestTable);
+        assertEquals(List.of("COL1", "COL3"), processor.columnsIngestTable.get("MY_TABLE"));
     }
 
-    private AbstractConfig createConfig() {
-        return new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of());
+    @Test
+    void testKnownIngestTablesPopulatedOnGetOrCreateBuffer() {
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        processor.bufferInitialCapacity = 100;
+
+        processor.getOrCreateBuffer("MY_TABLE");
+
+        assertTrue(processor.knownIngestTables.contains("MY_TABLE_INGEST"),
+                "knownIngestTables should contain MY_TABLE_INGEST after buffer creation");
     }
 
-    private CdcDbzSchemaProcessor createProcessor(String schemaName, String ingestTableName) {
+    @Test
+    void testExtractTableNameFromTopicWithDot() {
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        assertEquals("tabelaX", processor.extractTableNameFromTopic("compras.loja-b.tabelaX"));
+        assertEquals("tabelaZ", processor.extractTableNameFromTopic("compras.loja-c.tabelaZ"));
+    }
+
+    @Test
+    void testExtractTableNameFromTopicWithoutDotFallsBackToTableName() {
+        var processor = createProcessor("MY_SCHEMA", "MY_TABLE");
+        assertEquals("MY_TABLE", processor.extractTableNameFromTopic("no_dot_topic"));
+        assertEquals("MY_TABLE", processor.extractTableNameFromTopic(null));
+    }
+
+    private CdcDbzSchemaProcessor createProcessor(String schemaName, String tableBaseName) {
         var processor = new CdcDbzSchemaProcessor();
         processor.connection = mock(Connection.class);
         processor.schemaName = schemaName;
-        processor.ingestTableName = ingestTableName;
+        processor.tableName = tableBaseName;
         processor.ignoreColumns = new ArrayList<>();
         return processor;
     }

--- a/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorMiscTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/AbstractProcessorMiscTest.java
@@ -1,0 +1,95 @@
+package br.com.datastreambrasil.v3;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class AbstractProcessorMiscTest {
+
+    private CdcDbzSchemaProcessor processor(boolean processMultiTables, String tableName) {
+        var p = new CdcDbzSchemaProcessor();
+        p.connection = mock(Connection.class);
+        p.tableName = tableName;
+        p.processMultiTables = processMultiTables;
+        p.ignoreColumns = new ArrayList<>();
+        p.excludeIngestAdditionalFields = new ArrayList<>();
+        return p;
+    }
+
+    // ── extractTableName ─────────────────────────────────────────────────────
+
+    @Test
+    void extractTableName_multiTables_dotSeparatedTopic_returnsLastSegment() {
+        var p = processor(true, "DEFAULT_TABLE");
+        assertEquals("orders", p.extractTableName("server.schema.orders"));
+    }
+
+    @Test
+    void extractTableName_multiTables_singleDotTopic_returnsLastSegment() {
+        var p = processor(true, "DEFAULT_TABLE");
+        assertEquals("orders", p.extractTableName("schema.orders"));
+    }
+
+    @Test
+    void extractTableName_multiTables_topicWithoutDot_returnsConfiguredTableName() {
+        var p = processor(true, "DEFAULT_TABLE");
+        assertEquals("DEFAULT_TABLE", p.extractTableName("no_dot_topic"));
+    }
+
+    @Test
+    void extractTableName_multiTables_nullTopic_returnsConfiguredTableName() {
+        var p = processor(true, "DEFAULT_TABLE");
+        assertEquals("DEFAULT_TABLE", p.extractTableName(null));
+    }
+
+    @Test
+    void extractTableName_singleTable_topicWithDot_returnsConfiguredTableName() {
+        var p = processor(false, "DEFAULT_TABLE");
+        assertEquals("DEFAULT_TABLE", p.extractTableName("server.schema.orders"));
+    }
+
+    // ── configParameters ─────────────────────────────────────────────────────
+
+    @Test
+    void configParameters_mapsAllConfigFieldsToProcessorState() {
+        var p = new CdcDbzSchemaProcessor();
+        p.ignoreColumns = new ArrayList<>();
+        p.excludeIngestAdditionalFields = new ArrayList<>();
+        p.timestampFieldsConvert = new ArrayList<>();
+        p.dateFieldsConvert = new ArrayList<>();
+        p.timeFieldsConvert = new ArrayList<>();
+
+        var config = new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
+                "schema", "MY_SCHEMA",
+                "table", "MY_TABLE",
+                "stage", "MY_STAGE",
+                "timestamp_fields_convert", "created_at,updated_at",
+                "date_fields_convert", "birth_date",
+                "time_fields_convert", "start_time",
+                "ignore_columns", "DELETED_AT",
+                "process_multiples_tables", "true",
+                "find_columns_in_metadata", "true",
+                "must_process_read_only_messages", "false"
+        ));
+
+        p.configParameters(config);
+
+        assertEquals("MY_SCHEMA", p.schemaName);
+        assertEquals("MY_TABLE", p.tableName);
+        assertEquals("MY_STAGE", p.stageName);
+        assertEquals(List.of("created_at", "updated_at"), p.timestampFieldsConvert);
+        assertEquals(List.of("birth_date"), p.dateFieldsConvert);
+        assertEquals(List.of("start_time"), p.timeFieldsConvert);
+        assertEquals(List.of("DELETED_AT"), p.ignoreColumns);
+        assertEquals(true, p.processMultiTables);
+        assertEquals(true, p.findInColumnsMetadata);
+        assertEquals(false, p.mustProcessReadOnlyMessages);
+    }
+}

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorMultiTableTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorMultiTableTest.java
@@ -1,0 +1,286 @@
+package br.com.datastreambrasil.v3;
+
+import net.snowflake.client.jdbc.SnowflakeConnection;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CdcDbzSchemaProcessorMultiTableTest {
+
+    private static Schema valueAfterBeforeSchema;
+    private static Schema valueSchema;
+    private static Schema keySchema;
+
+    @BeforeAll
+    static void beforeTest() {
+        valueAfterBeforeSchema = SchemaBuilder.struct()
+                .field("Id", Schema.STRING_SCHEMA)
+                .field("Name", Schema.STRING_SCHEMA)
+                .build();
+        valueSchema = SchemaBuilder.struct()
+                .field("before", valueAfterBeforeSchema)
+                .field("after", valueAfterBeforeSchema)
+                .field("op", Schema.STRING_SCHEMA)
+                .build();
+        keySchema = SchemaBuilder.struct()
+                .field("id", Schema.OPTIONAL_STRING_SCHEMA)
+                .build();
+    }
+
+    @Test
+    void testFlushWithSuccess_ThreeTables_noException() throws SQLException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.processMultiTables = true;
+        var statementMock = prepareForMultiTableFlush(processor, List.of("tabelaX", "tabelaY", "tabelaZ"));
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicA.tabelaX", "1", "2"));
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicB.tabelaY", "3"));
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicC.tabelaZ", "4", "5"));
+
+        assertEquals(3, processor.buffer.size(), "Buffer must have 3 tables before flush");
+
+        assertDoesNotThrow(() -> processor.flush(null),
+                "flush() must not throw ConcurrentModificationException when iterating over multiple tables");
+    }
+
+    @Test
+    void testFlushWithSuccess_TwoTables_eachTableGetsCopyAndMergeStatements() throws SQLException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.processMultiTables = true;
+        var statementMock = prepareForMultiTableFlush(processor, List.of("tabelaX", "tabelaZ"));
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicA.tabelaX", "1"));
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicB.tabelaZ", "2"));
+
+        processor.flush(null);
+
+        verify(statementMock, times(2)).executeLargeUpdate(matches("COPY.*"));
+        verify(statementMock, times(2)).executeLargeUpdate(matches("MERGE.*"));
+    }
+
+    @Test
+    void testFlushWithSuccess_ThreeTables_bufferEmptyAfterFlush() throws SQLException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.processMultiTables = true;
+        prepareForMultiTableFlush(processor, List.of("tabelaX", "tabelaY", "tabelaZ"));
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicA.tabelaX", "1"));
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicB.tabelaY", "2"));
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicC.tabelaZ", "3"));
+
+        processor.flush(null);
+
+        assertEquals(0, processor.buffer.size(), "All table entries must be removed from buffer after flush");
+    }
+
+    @Test
+    void testFlushWithSuccess_MultiTable_stageNameIsTableBaseName() throws SQLException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.processMultiTables = true;
+        prepareForMultiTableFlush(processor, List.of("tabelaX"));
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicA.tabelaX", "1"));
+        processor.flush(null);
+
+        verify(processor.snowflakeConnection, times(1))
+                .uploadStream(eq("tabelaX"), eq("/"), any(), any(), eq(true));
+    }
+
+    @Test
+    void testPutIsolation_recordsRoutedToCorrectBuffer() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "default_table";
+        processor.bufferInitialCapacity = 10;
+        processor.processMultiTables = true;
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        processor.put(generateCreateEventsForTopic(dt, "schema.src.tabelaX", "1", "2", "3"));
+        processor.put(generateCreateEventsForTopic(dt, "schema.src.tabelaZ", "10", "20"));
+
+        var bufferX = processor.buffer.get("tabelaX");
+        var bufferZ = processor.buffer.get("tabelaZ");
+
+        assertNotNull(bufferX, "Buffer for tabelaX must exist");
+        assertNotNull(bufferZ, "Buffer for tabelaZ must exist");
+        assertEquals(3, bufferX.size(), "tabelaX buffer must contain exactly 3 records");
+        assertEquals(2, bufferZ.size(), "tabelaZ buffer must contain exactly 2 records");
+        assertNull(bufferZ.get("1"), "Record '1' from tabelaX must not appear in tabelaZ buffer");
+        assertNull(bufferX.get("10"), "Record '10' from tabelaZ must not appear in tabelaX buffer");
+    }
+
+    @Test
+    void testPutIsolation_samePkInDifferentTables_doNotCollide() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "default_table";
+        processor.bufferInitialCapacity = 10;
+        processor.processMultiTables = true;
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        processor.put(generateCreateEventsForTopic(dt, "schema.src.tabelaX", "1"));
+        processor.put(generateDeleteEventsForTopic(dt, "schema.src.tabelaZ", "1"));
+
+        var bufferX = processor.buffer.get("tabelaX");
+        var bufferZ = processor.buffer.get("tabelaZ");
+
+        assertNotNull(bufferX.get("1"), "PK '1' must exist in tabelaX buffer");
+        assertNotNull(bufferZ.get("1"), "PK '1' must exist in tabelaZ buffer");
+        assertEquals("c", bufferX.get("1").op(), "tabelaX pk='1' must be a create");
+        assertEquals("d", bufferZ.get("1").op(), "tabelaZ pk='1' must be a delete");
+    }
+
+    @Test
+    void testFlushWithSuccess_MixedOps_createInOneTable_deleteInOther() throws SQLException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.processMultiTables = true;
+        var statementMock = prepareForMultiTableFlush(processor, List.of("tabelaX", "tabelaZ"));
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        processor.put(generateCreateEventsForTopic(dt, "schema.topicA.tabelaX", "1"));
+        processor.put(generateDeleteEventsForTopic(dt, "schema.topicB.tabelaZ", "2"));
+
+        processor.flush(null);
+
+        // Both tables trigger their own COPY
+        verify(statementMock, times(2)).executeLargeUpdate(matches("COPY.*"));
+        // Only tabelaX has inserts → 1 MERGE
+        verify(statementMock, times(1)).executeLargeUpdate(matches("MERGE.*"));
+        // Only tabelaZ has deletes → 1 DELETE
+        verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE.*"));
+        assertEquals(0, processor.buffer.size(), "Buffer must be empty after flush");
+    }
+
+    @Test
+    void testPutIsolation_multipleTopicsSameSuffix_distinctBufferEntries() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "default_table";
+        processor.bufferInitialCapacity = 10;
+        processor.processMultiTables = true;
+        var dt = LocalDateTime.of(2025, 6, 3, 10, 0, 0);
+
+        // Different full topics but all resolve to the same table name via last segment
+        processor.put(generateCreateEventsForTopic(dt, "prefix.source_a.orders", "1", "2"));
+        processor.put(generateUpdateEventsForTopic(dt, "prefix.source_b.orders", "1"));
+
+        // Both resolve to "orders" — update on id=1 must override the create
+        var bufferOrders = processor.buffer.get("orders");
+        assertNotNull(bufferOrders, "Buffer for 'orders' must exist");
+        assertEquals(2, bufferOrders.size(), "Buffer must have 2 entries (id=1 updated, id=2 created)");
+        assertEquals("u", bufferOrders.get("1").op(), "id=1 must reflect the latest update operation");
+        assertEquals("c", bufferOrders.get("2").op(), "id=2 must remain a create operation");
+    }
+
+    private Statement prepareForMultiTableFlush(CdcDbzSchemaProcessor processor,
+                                                List<String> tableNames) throws SQLException {
+        processor.snowflakeConnection = mock(SnowflakeConnection.class);
+        processor.connection = mock(Connection.class);
+        var statementMock = mock(Statement.class);
+        when(processor.connection.createStatement()).thenReturn(statementMock);
+
+        processor.configParameters(generateConfigMultiTables());
+
+        for (String tableName : tableNames) {
+            var upper = tableName.toUpperCase();
+            processor.columnsIngestTable.put(upper + "_INGEST",
+                    List.of("id", "name", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"));
+            processor.columnsFinalTable.put(upper, List.of("id", "name"));
+        }
+
+        return statementMock;
+    }
+
+    private AbstractConfig generateConfigMultiTables() {
+        return new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
+                "schema", "test_schema",
+                "table", "default_table",
+                "stage", "test_stage",
+                "find_columns_in_metadata", Boolean.FALSE,
+                "process_multiples_tables", Boolean.TRUE
+        ));
+    }
+
+    private Collection<SinkRecord> generateCreateEventsForTopic(LocalDateTime dt, String topic, String... ids) {
+        var records = new ArrayList<SinkRecord>();
+        for (int i = 0; i < ids.length; i++) {
+            var id = ids[i];
+            records.add(new SinkRecord(
+                    topic, 0, keySchema,
+                    new Struct(keySchema).put("id", id),
+                    valueSchema,
+                    new Struct(valueSchema)
+                            .put("after", new Struct(valueAfterBeforeSchema)
+                                    .put("Id", id)
+                                    .put("Name", "Name " + id))
+                            .put("op", CdcDbzSchemaProcessor.debeziumOperation.c.name()),
+                    i));
+        }
+        return records;
+    }
+
+    private Collection<SinkRecord> generateUpdateEventsForTopic(LocalDateTime dt, String topic, String... ids) {
+        var records = new ArrayList<SinkRecord>();
+        for (int i = 0; i < ids.length; i++) {
+            var id = ids[i];
+            records.add(new SinkRecord(
+                    topic, 0, keySchema,
+                    new Struct(keySchema).put("id", id),
+                    valueSchema,
+                    new Struct(valueSchema)
+                            .put("before", new Struct(valueAfterBeforeSchema)
+                                    .put("Id", id)
+                                    .put("Name", "Name " + id))
+                            .put("after", new Struct(valueAfterBeforeSchema)
+                                    .put("Id", id)
+                                    .put("Name", "Name updated " + id))
+                            .put("op", CdcDbzSchemaProcessor.debeziumOperation.u.name()),
+                    i));
+        }
+        return records;
+    }
+
+    private Collection<SinkRecord> generateDeleteEventsForTopic(LocalDateTime dt, String topic, String... ids) {
+        var records = new ArrayList<SinkRecord>();
+        for (int i = 0; i < ids.length; i++) {
+            var id = ids[i];
+            records.add(new SinkRecord(
+                    topic, 0, keySchema,
+                    new Struct(keySchema).put("id", id),
+                    valueSchema,
+                    new Struct(valueSchema)
+                            .put("before", new Struct(valueAfterBeforeSchema)
+                                    .put("Id", id)
+                                    .put("Name", "Name " + id))
+                            .put("op", CdcDbzSchemaProcessor.debeziumOperation.d.name()),
+                    i));
+        }
+        return records;
+    }
+}

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorMultiTableTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorMultiTableTest.java
@@ -151,10 +151,10 @@ class CdcDbzSchemaProcessorMultiTableTest {
         var bufferX = processor.buffer.get("tabelaX");
         var bufferZ = processor.buffer.get("tabelaZ");
 
-        assertNotNull(bufferX.get("1+c"), "PK '1' (create) must exist in tabelaX buffer");
-        assertNotNull(bufferZ.get("1+d"), "PK '1' (delete) must exist in tabelaZ buffer");
-        assertEquals("c", bufferX.get("1+c").op(), "tabelaX pk='1' must be a create");
-        assertEquals("d", bufferZ.get("1+d").op(), "tabelaZ pk='1' must be a delete");
+        assertNotNull(bufferX.get("1"), "PK '1' must exist in tabelaX buffer");
+        assertNotNull(bufferZ.get("1"), "PK '1' must exist in tabelaZ buffer");
+        assertEquals("c", bufferX.get("1").op(), "tabelaX pk='1' must be a create");
+        assertEquals("d", bufferZ.get("1").op(), "tabelaZ pk='1' must be a delete");
     }
 
     @Test
@@ -190,14 +190,12 @@ class CdcDbzSchemaProcessorMultiTableTest {
         processor.put(generateCreateEventsForTopic(dt, "prefix.source_a.orders", "1", "2"));
         processor.put(generateUpdateEventsForTopic(dt, "prefix.source_b.orders", "1"));
 
-        // Both topics resolve to "orders" — create and update for id=1 coexist as separate entries (key = pk+op)
+        // Both resolve to "orders" — update on id=1 must override the create
         var bufferOrders = processor.buffer.get("orders");
         assertNotNull(bufferOrders, "Buffer for 'orders' must exist");
-        // 3 entries: 1+c (create), 2+c (create), 1+u (update)
-        assertEquals(3, bufferOrders.size(), "Buffer must have 3 entries: create and update for id=1, and create for id=2");
-        assertEquals("c", bufferOrders.get("1+c").op(), "id=1 create entry must exist");
-        assertEquals("u", bufferOrders.get("1+u").op(), "id=1 update entry must exist");
-        assertEquals("c", bufferOrders.get("2+c").op(), "id=2 must remain a create operation");
+        assertEquals(2, bufferOrders.size(), "Buffer must have 2 entries (id=1 updated, id=2 created)");
+        assertEquals("u", bufferOrders.get("1").op(), "id=1 must reflect the latest update operation");
+        assertEquals("c", bufferOrders.get("2").op(), "id=2 must remain a create operation");
     }
 
     private Statement prepareForMultiTableFlush(CdcDbzSchemaProcessor processor,

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorMultiTableTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorMultiTableTest.java
@@ -151,10 +151,10 @@ class CdcDbzSchemaProcessorMultiTableTest {
         var bufferX = processor.buffer.get("tabelaX");
         var bufferZ = processor.buffer.get("tabelaZ");
 
-        assertNotNull(bufferX.get("1"), "PK '1' must exist in tabelaX buffer");
-        assertNotNull(bufferZ.get("1"), "PK '1' must exist in tabelaZ buffer");
-        assertEquals("c", bufferX.get("1").op(), "tabelaX pk='1' must be a create");
-        assertEquals("d", bufferZ.get("1").op(), "tabelaZ pk='1' must be a delete");
+        assertNotNull(bufferX.get("1+c"), "PK '1' (create) must exist in tabelaX buffer");
+        assertNotNull(bufferZ.get("1+d"), "PK '1' (delete) must exist in tabelaZ buffer");
+        assertEquals("c", bufferX.get("1+c").op(), "tabelaX pk='1' must be a create");
+        assertEquals("d", bufferZ.get("1+d").op(), "tabelaZ pk='1' must be a delete");
     }
 
     @Test
@@ -190,12 +190,14 @@ class CdcDbzSchemaProcessorMultiTableTest {
         processor.put(generateCreateEventsForTopic(dt, "prefix.source_a.orders", "1", "2"));
         processor.put(generateUpdateEventsForTopic(dt, "prefix.source_b.orders", "1"));
 
-        // Both resolve to "orders" — update on id=1 must override the create
+        // Both topics resolve to "orders" — create and update for id=1 coexist as separate entries (key = pk+op)
         var bufferOrders = processor.buffer.get("orders");
         assertNotNull(bufferOrders, "Buffer for 'orders' must exist");
-        assertEquals(2, bufferOrders.size(), "Buffer must have 2 entries (id=1 updated, id=2 created)");
-        assertEquals("u", bufferOrders.get("1").op(), "id=1 must reflect the latest update operation");
-        assertEquals("c", bufferOrders.get("2").op(), "id=2 must remain a create operation");
+        // 3 entries: 1+c (create), 2+c (create), 1+u (update)
+        assertEquals(3, bufferOrders.size(), "Buffer must have 3 entries: create and update for id=1, and create for id=2");
+        assertEquals("c", bufferOrders.get("1+c").op(), "id=1 create entry must exist");
+        assertEquals("u", bufferOrders.get("1+u").op(), "id=1 update entry must exist");
+        assertEquals("c", bufferOrders.get("2+c").op(), "id=2 must remain a create operation");
     }
 
     private Statement prepareForMultiTableFlush(CdcDbzSchemaProcessor processor,

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorStopTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorStopTest.java
@@ -1,0 +1,95 @@
+package br.com.datastreambrasil.v3;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.junit.jupiter.api.Test;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class CdcDbzSchemaProcessorStopTest {
+
+    private Scheduler schedulerFieldOf(CdcDbzSchemaProcessor p) throws Exception {
+        Field f = CdcDbzSchemaProcessor.class.getDeclaredField("scheduler");
+        f.setAccessible(true);
+        return (Scheduler) f.get(p);
+    }
+
+    private void setScheduler(CdcDbzSchemaProcessor p, Scheduler scheduler) throws Exception {
+        Field f = CdcDbzSchemaProcessor.class.getDeclaredField("scheduler");
+        f.setAccessible(true);
+        f.set(p, scheduler);
+    }
+
+    private CdcDbzSchemaProcessor processorWithMockConnection() {
+        var p = new CdcDbzSchemaProcessor();
+        p.connection = mock(Connection.class);
+        p.knownIngestTables = ConcurrentHashMap.newKeySet();
+        return p;
+    }
+
+    private AbstractConfig configWithCleanupEnabled() {
+        return new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
+                "schema", "MY_SCHEMA",
+                "table", "MY_TABLE",
+                "stage", "MY_STAGE"
+        ));
+    }
+
+    // ── stop ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void stop_withNullScheduler_doesNotThrow() {
+        var p = new CdcDbzSchemaProcessor();
+        assertDoesNotThrow(p::stop, "stop() with no scheduler started should be a no-op");
+    }
+
+    @Test
+    void stop_withRunningScheduler_shutsDownGracefully() throws Exception {
+        var p = processorWithMockConnection();
+        p.startCleanUpJob(configWithCleanupEnabled());
+        assertNotNull(schedulerFieldOf(p), "Scheduler should be set after startCleanUpJob");
+
+        assertDoesNotThrow(p::stop, "stop() should shut down the scheduler without throwing");
+    }
+
+    @Test
+    void stop_whenSchedulerThrows_exceptionSwallowed() throws Exception {
+        var p = new CdcDbzSchemaProcessor();
+        var mockScheduler = mock(Scheduler.class);
+        doThrow(new SchedulerException("forced error")).when(mockScheduler).shutdown();
+        setScheduler(p, mockScheduler);
+
+        assertDoesNotThrow(p::stop,
+                "SchedulerException in stop() must be caught and not re-thrown");
+        verify(mockScheduler).shutdown();
+    }
+
+    // ── startCleanUpJob ───────────────────────────────────────────────────────
+
+    @Test
+    void startCleanUpJob_whenDisabled_schedulerRemainsNull() throws Exception {
+        var p = processorWithMockConnection();
+        var config = new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
+                "schema", "MY_SCHEMA",
+                "table", "MY_TABLE",
+                "stage", "MY_STAGE",
+                "job_cleanup_disable", "true"
+        ));
+
+        p.startCleanUpJob(config);
+
+        assertNull(schedulerFieldOf(p),
+                "Scheduler must not be created when cleanup job is disabled");
+    }
+}

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -278,8 +278,8 @@ class CdcDbzSchemaProcessorTest {
         verify(statementMock, times(1)).executeLargeUpdate(matches("MERGE.*"));
         verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE(.*)final.id = ingest.id"));
         assertEquals(0, processor.buffer.size(), "Buffer map should be empty after flush");
-        assertTrue(Files.isDirectory(Path.of("/mnt/data/csv_data_to_stage/test_stage")));
-        assertTrue(Files.list(Path.of("/mnt/data/csv_data_to_stage/test_stage")).toList().isEmpty());
+        assertTrue(Files.isDirectory(Path.of("/mnt/data/csv_data_to_stage/test_table")));
+        assertTrue(Files.list(Path.of("/mnt/data/csv_data_to_stage/test_table")).toList().isEmpty());
     }
 
     @Test
@@ -293,13 +293,13 @@ class CdcDbzSchemaProcessorTest {
         var tableBuffer = processor.buffer.get("test_table");
         var csvBaos = processor.prepareOrderedColumnsBasedOnTargetTable(blockID,
                 List.of("id", "name", "timestamp", "time", "date", "desc", IHTOPIC, IHOFFSET, IHPARTITION, IHOP, IHBLOCKID, IHDATETIME),
-                tableBuffer);
+                tableBuffer, "test_table");
         var pattern = Pattern.compile("""
                 "1","Name 1","2018-01-10T08:30:40","10:30:40","2018-01-09",,"test_topic","0","0","c","111",(?<msgtimestampc>.*)
                 "2","Name 2","2018-01-10T08:30:40","10:30:40","2018-01-09",,"test_topic","0","0","d","111",(?<msgtimestampd>.*)
                 """);
         var fileData = IOUtils.toString(Files.newInputStream(csvBaos), "UTF-8");
-        var files = Files.list(Path.of("/mnt/data/csv_data_to_stage/test_stage")).toList();
+        var files = Files.list(Path.of("/mnt/data/csv_data_to_stage/test_table")).toList();
         for (Path f : files) {
             Files.deleteIfExists(Path.of(f.toFile().getAbsolutePath()));
         }

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -310,26 +310,34 @@ class CdcDbzSchemaProcessorTest {
     @Test
     void testFlushWithSuccess() throws SQLException, IOException {
         var processor = new CdcDbzSchemaProcessor();
+        processor.findInColumnsMetadata = true;
         var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
         var statementMock = prepareToFlush(processor);
         processor.put(generateCreateEvents(dt, "1", "2", "3"));
         processor.put(generateUpdateEvents(dt, "new", "4"));
         processor.put(generateDeleteEvents(dt, "5"));
+        processor.columnsIngestTable.put("TEST_TABLE_INGEST",
+                List.of("id", "name", "timestamp", "time", "date", "desc", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"));
+        processor.columnsFinalTable.put("TEST_TABLE",
+                List.of("id", "name", "timestamp", "time", "date", "desc"));
+
         processor.flush(null);
 
         verify(processor.snowflakeConnection, times(1)).uploadStream(any(), eq("/"),
                 assertArg(c -> assertNotNull(c, "CSV data stream should should not be null")), any(), eq(true));
         verify(statementMock, times(1)).executeLargeUpdate(matches("COPY.*"));
         verify(statementMock, times(1)).executeLargeUpdate(matches("MERGE.*"));
-        verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE(.*)final.id = ingest.id"));
+        verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE.*"));
         assertEquals(0, processor.buffer.size(), "Buffer map should be empty after flush");
         assertTrue(Files.isDirectory(Path.of("/mnt/data/csv_data_to_stage/test_table")));
         assertTrue(Files.list(Path.of("/mnt/data/csv_data_to_stage/test_table")).toList().isEmpty());
     }
 
     @Test
-    void testFlushWithSuccess_MultiTables() throws SQLException, IOException {
+    void testFlushWithSuccess_MultiTables() throws SQLException {
         var processor = new CdcDbzSchemaProcessor();
+        processor.processMultiTables = true;
+        processor.mustProcessReadOnlyMessages = true;
         var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
         var statementMock = prepareToFlushMultiTables(processor);
         processor.put(generateCreateEvents(dt, "1", "2", "3"));
@@ -342,7 +350,7 @@ class CdcDbzSchemaProcessorTest {
                 assertArg(c -> assertNotNull(c, "CSV data stream should not be null")), any(), eq(true));
         verify(statementMock, times(1)).executeLargeUpdate(matches("COPY.*"));
         verify(statementMock, times(1)).executeLargeUpdate(matches("MERGE.*"));
-        verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE(.*)final.id = ingest.id"));
+        verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE.*"));
         assertEquals(0, processor.buffer.size(), "Buffer map should be empty after flush");
     }
 
@@ -412,7 +420,7 @@ class CdcDbzSchemaProcessorTest {
                 "test_table", "test_table_INGEST");
         processor.configParameters(generateConfigMultiTables());
         // Simulates columns pre-loaded by preloadAllIngestTableColumns() — uppercase key
-        processor.columnsIngestTable.put("TEST_TABLE",
+        processor.columnsIngestTable.put("TEST_TABLE_INGEST",
                 List.of("id", "name", "timestamp", "time", "date", "desc", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"));
         processor.columnsFinalTable.put("TEST_TABLE",
                 List.of("id", "name", "timestamp", "time", "date", "desc"));
@@ -439,7 +447,7 @@ class CdcDbzSchemaProcessorTest {
                 "timestamp_fields_convert", "timestamp",
                 "date_fields_convert", "date",
                 "time_fields_convert", "time",
-                "find_columns_in_metadata", Boolean.TRUE,
+                "find_columns_in_metadata", Boolean.FALSE,
                 "process_multiples_tables", Boolean.TRUE
         ));
     }

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -126,6 +126,7 @@ class CdcDbzSchemaProcessorTest {
         var processor = new CdcDbzSchemaProcessor();
         processor.tableName = "default_table";
         processor.bufferInitialCapacity = 10;
+        processor.processMultiTables = true;
         var dt = LocalDateTime.of(2025, 1, 20, 10, 30, 40);
 
         // Records with dot-separated topics — table name extracted from last segment

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -84,41 +84,40 @@ class CdcDbzSchemaProcessorTest {
         processor.put(generateUpdateEvents(dt, "update 001", "10"));//this update should be ignored, because it will be overridden by the next update event
         processor.put(generateUpdateEvents(dt, "update 002", "10"));
         processor.put(generateDeleteEvents(dt, "20"));
-        processor.put(generateDeleteEvents(dt, "3")); //this delete will override the create event for id 3
+        processor.put(generateDeleteEvents(dt, "3")); //delete and create for id 3 coexist as separate entries (key = pk+op)
 
         var tableBuffer = processor.buffer.get("test_table");
-        assertEquals(5, tableBuffer.size());
+        // 6 entries: 1+c, 2+c, 3+c, 3+d, 10+u (dedup'd), 20+d
+        assertEquals(6, tableBuffer.size());
 
         var itemIdx = "1";
         //assert item create
-        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx + "+c").event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx + "+c").event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("c", tableBuffer.get(itemIdx).op());
+        assertEquals("c", tableBuffer.get(itemIdx + "+c").op());
 
         //assert item update
         itemIdx = "10";
-        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx + "+u").event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name update 002 " + itemIdx, tableBuffer.get(itemIdx).event().stream()
+        assertEquals("Name update 002 " + itemIdx, tableBuffer.get(itemIdx + "+u").event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("u", tableBuffer.get(itemIdx).op());
+        assertEquals("u", tableBuffer.get(itemIdx + "+u").op());
 
-        //asert item delete
+        //assert item delete
         itemIdx = "20";
-        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx + "+d").event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx + "+d").event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("d", tableBuffer.get(itemIdx).op());
+        assertEquals("d", tableBuffer.get(itemIdx + "+d").op());
 
+        // id=3: create and delete coexist as separate buffer entries
         itemIdx = "3";
-        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
-                .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
-                .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("d", tableBuffer.get(itemIdx).op());
+        assertEquals("c", tableBuffer.get(itemIdx + "+c").op());
+        assertEquals("d", tableBuffer.get(itemIdx + "+d").op());
     }
 
     @Test
@@ -176,7 +175,7 @@ class CdcDbzSchemaProcessorTest {
         var tableBuffer = processor.buffer.get("test_table");
         assertNotNull(tableBuffer, "Buffer should contain create events");
         assertEquals(1, tableBuffer.size(), "Only create event should be in buffer; read events must be discarded");
-        assertEquals("c", tableBuffer.get("3").op());
+        assertEquals("c", tableBuffer.get("3+c").op());
     }
 
     @Test
@@ -191,8 +190,8 @@ class CdcDbzSchemaProcessorTest {
         var tableBuffer = processor.buffer.get("test_table");
         assertNotNull(tableBuffer, "Buffer should contain read events when mustProcessReadOnlyMessages=true");
         assertEquals(2, tableBuffer.size());
-        assertEquals("r", tableBuffer.get("1").op());
-        assertEquals("r", tableBuffer.get("2").op());
+        assertEquals("r", tableBuffer.get("1+r").op());
+        assertEquals("r", tableBuffer.get("2+r").op());
     }
 
     @Test

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 class CdcDbzSchemaProcessorTest {
 
@@ -331,6 +332,32 @@ class CdcDbzSchemaProcessorTest {
         assertEquals(0, processor.buffer.size(), "Buffer map should be empty after flush");
         assertTrue(Files.isDirectory(Path.of("/mnt/data/csv_data_to_stage/test_table")));
         assertTrue(Files.list(Path.of("/mnt/data/csv_data_to_stage/test_table")).toList().isEmpty());
+    }
+
+    @Test
+    void testFlushMergeQueryContainsHashDeduplicationCondition() throws SQLException, IOException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.findInColumnsMetadata = true;
+        var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
+        var statementMock = prepareToFlush(processor);
+        processor.put(generateCreateEvents(dt, "1"));
+        processor.put(generateUpdateEvents(dt, "new", "2"));
+        processor.columnsIngestTable.put("TEST_TABLE_INGEST",
+                List.of("id", "name", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"));
+        processor.columnsFinalTable.put("TEST_TABLE", List.of("id", "name"));
+
+        processor.flush(null);
+
+        var sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(statementMock, times(2)).executeLargeUpdate(sqlCaptor.capture()); // COPY + MERGE
+        var mergeSQL = sqlCaptor.getAllValues().stream()
+                .filter(sql -> sql.startsWith("MERGE"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("MERGE statement not generated"));
+        assertTrue(mergeSQL.contains("WHEN MATCHED AND HASH(final."), "MERGE must guard update with HASH on the existing row");
+        assertTrue(mergeSQL.contains("<> HASH(ingest."), "MERGE must compare existing HASH against incoming HASH");
+        assertTrue(mergeSQL.contains("HASH(final.id,final.name)"), "HASH must cover all final table columns");
+        assertTrue(mergeSQL.contains("HASH(ingest.id,ingest.name)"), "HASH must cover all ingest columns mapped to final");
     }
 
     @Test

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -361,6 +361,58 @@ class CdcDbzSchemaProcessorTest {
     }
 
     @Test
+    void testFlushCopyOnlyTrue_OnlyCopyExecutedWithPurgeFalse() throws SQLException, IOException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.findInColumnsMetadata = true;
+        var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
+        var statementMock = prepareToFlush(processor);
+        processor.copyOnly = true;
+        processor.put(generateCreateEvents(dt, "1", "2"));
+        processor.put(generateUpdateEvents(dt, "new", "3"));
+        processor.put(generateDeleteEvents(dt, "4"));
+        processor.columnsIngestTable.put("TEST_TABLE_INGEST",
+                List.of("id", "name", "timestamp", "time", "date", "desc", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"));
+        processor.columnsFinalTable.put("TEST_TABLE",
+                List.of("id", "name", "timestamp", "time", "date", "desc"));
+
+        processor.flush(null);
+
+        var sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(statementMock, times(1)).executeLargeUpdate(sqlCaptor.capture());
+        var executedSQLs = sqlCaptor.getAllValues();
+        assertEquals(1, executedSQLs.size(), "Only COPY should be executed when copyOnly=true");
+        assertTrue(executedSQLs.get(0).startsWith("COPY"), "The only executed statement should be COPY");
+        assertTrue(executedSQLs.get(0).contains("PURGE = 'FALSE'"), "COPY query must use PURGE = 'FALSE' when copyOnly=true");
+        assertEquals(0, processor.buffer.size(), "Buffer should be empty after flush");
+    }
+
+    @Test
+    void testFlushCopyOnlyFalse_CopyQueryContainsPurgeTrue() throws SQLException, IOException {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.findInColumnsMetadata = true;
+        var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
+        var statementMock = prepareToFlush(processor);
+        // copyOnly defaults to false via configParameters(generateConfig())
+        processor.put(generateCreateEvents(dt, "1", "2"));
+        processor.put(generateUpdateEvents(dt, "new", "3"));
+        processor.put(generateDeleteEvents(dt, "4"));
+        processor.columnsIngestTable.put("TEST_TABLE_INGEST",
+                List.of("id", "name", "timestamp", "time", "date", "desc", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"));
+        processor.columnsFinalTable.put("TEST_TABLE",
+                List.of("id", "name", "timestamp", "time", "date", "desc"));
+
+        processor.flush(null);
+
+        var sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(statementMock, times(3)).executeLargeUpdate(sqlCaptor.capture()); // COPY + MERGE + DELETE
+        var copySQL = sqlCaptor.getAllValues().stream()
+                .filter(sql -> sql.startsWith("COPY"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("COPY statement not generated"));
+        assertTrue(copySQL.contains("PURGE = 'TRUE'"), "COPY query must use PURGE = 'TRUE' when copyOnly=false");
+    }
+
+    @Test
     void testFlushWithSuccess_MultiTables() throws SQLException {
         var processor = new CdcDbzSchemaProcessor();
         processor.processMultiTables = true;

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -84,40 +84,41 @@ class CdcDbzSchemaProcessorTest {
         processor.put(generateUpdateEvents(dt, "update 001", "10"));//this update should be ignored, because it will be overridden by the next update event
         processor.put(generateUpdateEvents(dt, "update 002", "10"));
         processor.put(generateDeleteEvents(dt, "20"));
-        processor.put(generateDeleteEvents(dt, "3")); //delete and create for id 3 coexist as separate entries (key = pk+op)
+        processor.put(generateDeleteEvents(dt, "3")); //this delete will override the create event for id 3
 
         var tableBuffer = processor.buffer.get("test_table");
-        // 6 entries: 1+c, 2+c, 3+c, 3+d, 10+u (dedup'd), 20+d
-        assertEquals(6, tableBuffer.size());
+        assertEquals(5, tableBuffer.size());
 
         var itemIdx = "1";
         //assert item create
-        assertEquals(itemIdx, tableBuffer.get(itemIdx + "+c").event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx + "+c").event().stream()
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("c", tableBuffer.get(itemIdx + "+c").op());
+        assertEquals("c", tableBuffer.get(itemIdx).op());
 
         //assert item update
         itemIdx = "10";
-        assertEquals(itemIdx, tableBuffer.get(itemIdx + "+u").event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name update 002 " + itemIdx, tableBuffer.get(itemIdx + "+u").event().stream()
+        assertEquals("Name update 002 " + itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("u", tableBuffer.get(itemIdx + "+u").op());
+        assertEquals("u", tableBuffer.get(itemIdx).op());
 
-        //assert item delete
+        //asert item delete
         itemIdx = "20";
-        assertEquals(itemIdx, tableBuffer.get(itemIdx + "+d").event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx + "+d").event().stream()
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("d", tableBuffer.get(itemIdx + "+d").op());
+        assertEquals("d", tableBuffer.get(itemIdx).op());
 
-        // id=3: create and delete coexist as separate buffer entries
         itemIdx = "3";
-        assertEquals("c", tableBuffer.get(itemIdx + "+c").op());
-        assertEquals("d", tableBuffer.get(itemIdx + "+d").op());
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
+                .filter(f -> f.name().equals("Id")).findFirst().get().data());
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
+                .filter(f -> f.name().equals("Name")).findFirst().get().data());
+        assertEquals("d", tableBuffer.get(itemIdx).op());
     }
 
     @Test
@@ -175,7 +176,7 @@ class CdcDbzSchemaProcessorTest {
         var tableBuffer = processor.buffer.get("test_table");
         assertNotNull(tableBuffer, "Buffer should contain create events");
         assertEquals(1, tableBuffer.size(), "Only create event should be in buffer; read events must be discarded");
-        assertEquals("c", tableBuffer.get("3+c").op());
+        assertEquals("c", tableBuffer.get("3").op());
     }
 
     @Test
@@ -190,8 +191,8 @@ class CdcDbzSchemaProcessorTest {
         var tableBuffer = processor.buffer.get("test_table");
         assertNotNull(tableBuffer, "Buffer should contain read events when mustProcessReadOnlyMessages=true");
         assertEquals(2, tableBuffer.size());
-        assertEquals("r", tableBuffer.get("1+r").op());
-        assertEquals("r", tableBuffer.get("2+r").op());
+        assertEquals("r", tableBuffer.get("1").op());
+        assertEquals("r", tableBuffer.get("2").op());
     }
 
     @Test

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -151,6 +151,50 @@ class CdcDbzSchemaProcessorTest {
     }
 
     @Test
+    void testPutSuccess_ReadMessageDiscardedWhenMustProcessReadOnlyMessagesFalse() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "test_table";
+        processor.bufferInitialCapacity = 10;
+        processor.mustProcessReadOnlyMessages = false;
+        var dt = LocalDateTime.of(2025, 1, 20, 10, 30, 40);
+        processor.put(generateReadEvents(dt, "1", "2", "3"));
+
+        assertTrue(processor.buffer.isEmpty(), "Buffer should be empty when all records are 'r' and mustProcessReadOnlyMessages=false");
+    }
+
+    @Test
+    void testPutSuccess_ReadMessageDiscardedMixedWithOtherOps() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "test_table";
+        processor.bufferInitialCapacity = 10;
+        processor.mustProcessReadOnlyMessages = false;
+        var dt = LocalDateTime.of(2025, 1, 20, 10, 30, 40);
+        processor.put(generateReadEvents(dt, "1", "2"));
+        processor.put(generateCreateEvents(dt, "3"));
+
+        var tableBuffer = processor.buffer.get("test_table");
+        assertNotNull(tableBuffer, "Buffer should contain create events");
+        assertEquals(1, tableBuffer.size(), "Only create event should be in buffer; read events must be discarded");
+        assertEquals("c", tableBuffer.get("3").op());
+    }
+
+    @Test
+    void testPutSuccess_ReadMessageProcessedWhenMustProcessReadOnlyMessagesTrue() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "test_table";
+        processor.bufferInitialCapacity = 10;
+        processor.mustProcessReadOnlyMessages = true;
+        var dt = LocalDateTime.of(2025, 1, 20, 10, 30, 40);
+        processor.put(generateReadEvents(dt, "1", "2"));
+
+        var tableBuffer = processor.buffer.get("test_table");
+        assertNotNull(tableBuffer, "Buffer should contain read events when mustProcessReadOnlyMessages=true");
+        assertEquals(2, tableBuffer.size());
+        assertEquals("r", tableBuffer.get("1").op());
+        assertEquals("r", tableBuffer.get("2").op());
+    }
+
+    @Test
     void testPutFailWithInvalidValueSchema() {
         var processor = new CdcDbzSchemaProcessor();
         assertThrows(InvalidStructException.class, () -> processor.put(List.of(new SinkRecord(
@@ -510,6 +554,30 @@ class CdcDbzSchemaProcessorTest {
             ));
         }
 
+        return records;
+    }
+
+    private Collection<SinkRecord> generateReadEvents(LocalDateTime dt, String... ids) {
+        var records = new ArrayList<SinkRecord>();
+        for (int i = 0; i < ids.length; i++) {
+            var id = ids[i];
+            records.add(new SinkRecord(
+                    "test_topic",
+                    0,
+                    keySchema,
+                    new Struct(keySchema).put("id", id),
+                    valueSchema,
+                    new Struct(valueSchema)
+                            .put("after", new Struct(valueAfterBeforeSchema)
+                                    .put("Id", id)
+                                    .put("Name", "Name " + id)
+                                    .put("timestamp", dt.toInstant(ZoneOffset.UTC).toEpochMilli())
+                                    .put("time", dt.getLong(ChronoField.NANO_OF_DAY))
+                                    .put("date", (int) dt.getLong(ChronoField.EPOCH_DAY)))
+                            .put("op", CdcDbzSchemaProcessor.debeziumOperation.r.name()),
+                    i
+            ));
+        }
         return records;
     }
 

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -283,6 +283,38 @@ class CdcDbzSchemaProcessorTest {
     }
 
     @Test
+    void testFlushWithSuccess_MultiTables() throws SQLException, IOException {
+        var processor = new CdcDbzSchemaProcessor();
+        var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
+        var statementMock = prepareToFlushMultiTables(processor);
+        processor.put(generateCreateEvents(dt, "1", "2", "3"));
+        processor.put(generateUpdateEvents(dt, "new", "4"));
+        processor.put(generateDeleteEvents(dt, "5"));
+        processor.flush(null);
+
+        // stageName = tableBaseName ("test_table") when processMultiTables = true
+        verify(processor.snowflakeConnection, times(1)).uploadStream(eq("test_table"), eq("/"),
+                assertArg(c -> assertNotNull(c, "CSV data stream should not be null")), any(), eq(true));
+        verify(statementMock, times(1)).executeLargeUpdate(matches("COPY.*"));
+        verify(statementMock, times(1)).executeLargeUpdate(matches("MERGE.*"));
+        verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE(.*)final.id = ingest.id"));
+        assertEquals(0, processor.buffer.size(), "Buffer map should be empty after flush");
+    }
+
+    @Test
+    void testFlushThrowsWhenTableNotPreloaded() throws SQLException {
+        var processor = new CdcDbzSchemaProcessor();
+        var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
+        mockConnections(processor,
+                List.of("id"), List.of("id", "ih_topic"), "test_table", "test_table_INGEST");
+        processor.configParameters(generateConfigMultiTables());
+        // columnsIngestTable intentionally not pre-populated
+        processor.put(generateCreateEvents(dt, "1"));
+
+        assertThrows(RuntimeException.class, () -> processor.flush(null));
+    }
+
+    @Test
     void testPrepareOrderedColumnsBasedOnTargetTableSuccess() throws Throwable {
         var processor = new CdcDbzSchemaProcessor();
         var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
@@ -328,6 +360,20 @@ class CdcDbzSchemaProcessorTest {
         return statementMock;
     }
 
+    private Statement prepareToFlushMultiTables(CdcDbzSchemaProcessor processor) throws SQLException {
+        var statementMock = mockConnections(processor,
+                List.of("id", "name", "timestamp", "time", "date", "desc"),
+                List.of("id", "name", "timestamp", "time", "date", "desc", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"),
+                "test_table", "test_table_INGEST");
+        processor.configParameters(generateConfigMultiTables());
+        // Simulates columns pre-loaded by preloadAllIngestTableColumns() — uppercase key
+        processor.columnsIngestTable.put("TEST_TABLE",
+                List.of("id", "name", "timestamp", "time", "date", "desc", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"));
+        processor.columnsFinalTable.put("TEST_TABLE",
+                List.of("id", "name", "timestamp", "time", "date", "desc"));
+        return statementMock;
+    }
+
     private AbstractConfig generateConfig() {
         return new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
                 "schema", "test_schema",
@@ -337,6 +383,19 @@ class CdcDbzSchemaProcessorTest {
                 "date_fields_convert", "date",
                 "time_fields_convert", "time",
                 "find_columns_in_metadata", Boolean.TRUE
+        ));
+    }
+
+    private AbstractConfig generateConfigMultiTables() {
+        return new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, Map.of(
+                "schema", "test_schema",
+                "table", "test_table",
+                "stage", "test_stage",
+                "timestamp_fields_convert", "timestamp",
+                "date_fields_convert", "date",
+                "time_fields_convert", "time",
+                "find_columns_in_metadata", Boolean.TRUE,
+                "process_multiples_tables", Boolean.TRUE
         ));
     }
 

--- a/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CdcDbzSchemaProcessorTest.java
@@ -1,7 +1,5 @@
 package br.com.datastreambrasil.v3;
 
-import br.com.datastreambrasil.v3.compress.CompressedMap;
-import br.com.datastreambrasil.v3.compress.KryoFactory;
 import br.com.datastreambrasil.v3.exception.InvalidStructException;
 import net.snowflake.client.jdbc.SnowflakeConnection;
 import net.snowflake.client.jdbc.internal.apache.commons.io.IOUtils;
@@ -79,45 +77,77 @@ class CdcDbzSchemaProcessorTest {
     @Test
     void testPutSuccess() {
         var processor = new CdcDbzSchemaProcessor();
-        processor.buffer = new CompressedMap<>(new KryoFactory(), 10);
+        processor.tableName = "test_table";
+        processor.bufferInitialCapacity = 10;
         var dt = LocalDateTime.of(2025, 1, 20, 10, 30, 40);
         processor.put(generateCreateEvents(dt, "1", "2", "3"));
         processor.put(generateUpdateEvents(dt, "update 001", "10"));//this update should be ignored, because it will be overridden by the next update event
         processor.put(generateUpdateEvents(dt, "update 002", "10"));
         processor.put(generateDeleteEvents(dt, "20"));
         processor.put(generateDeleteEvents(dt, "3")); //this delete will override the create event for id 3
-        assertEquals(5, processor.buffer.size());
+
+        var tableBuffer = processor.buffer.get("test_table");
+        assertEquals(5, tableBuffer.size());
 
         var itemIdx = "1";
         //assert item create
-        assertEquals(itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("c", processor.buffer.get(itemIdx).op());
+        assertEquals("c", tableBuffer.get(itemIdx).op());
 
         //assert item update
         itemIdx = "10";
-        assertEquals(itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name update 002 " + itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals("Name update 002 " + itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("u", processor.buffer.get(itemIdx).op());
+        assertEquals("u", tableBuffer.get(itemIdx).op());
 
         //asert item delete
         itemIdx = "20";
-        assertEquals(itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("d", processor.buffer.get(itemIdx).op());
+        assertEquals("d", tableBuffer.get(itemIdx).op());
 
         itemIdx = "3";
-        assertEquals(itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals(itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Id")).findFirst().get().data());
-        assertEquals("Name " + itemIdx, processor.buffer.get(itemIdx).event().stream()
+        assertEquals("Name " + itemIdx, tableBuffer.get(itemIdx).event().stream()
                 .filter(f -> f.name().equals("Name")).findFirst().get().data());
-        assertEquals("d", processor.buffer.get(itemIdx).op());
+        assertEquals("d", tableBuffer.get(itemIdx).op());
+    }
+
+    @Test
+    void testPutSuccess_MultipleTopics() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "default_table";
+        processor.bufferInitialCapacity = 10;
+        var dt = LocalDateTime.of(2025, 1, 20, 10, 30, 40);
+
+        // Records with dot-separated topics — table name extracted from last segment
+        processor.put(generateCreateEventsForTopic(dt, "compras.loja-b.tabelaX", "1", "2"));
+        processor.put(generateCreateEventsForTopic(dt, "compras.loja-c.tabelaZ", "3"));
+
+        assertTrue(processor.buffer.containsKey("tabelaX"), "Buffer should contain tabelaX");
+        assertTrue(processor.buffer.containsKey("tabelaZ"), "Buffer should contain tabelaZ");
+        assertEquals(2, processor.buffer.get("tabelaX").size());
+        assertEquals(1, processor.buffer.get("tabelaZ").size());
+    }
+
+    @Test
+    void testPutSuccess_TopicWithoutDotFallsBackToTableName() {
+        var processor = new CdcDbzSchemaProcessor();
+        processor.tableName = "fallback_table";
+        processor.bufferInitialCapacity = 10;
+        var dt = LocalDateTime.of(2025, 1, 20, 10, 30, 40);
+
+        processor.put(generateCreateEventsForTopic(dt, "no_dot_topic", "1"));
+
+        assertTrue(processor.buffer.containsKey("fallback_table"), "Buffer should use tableName as fallback");
     }
 
     @Test
@@ -247,7 +277,7 @@ class CdcDbzSchemaProcessorTest {
         verify(statementMock, times(1)).executeLargeUpdate(matches("COPY.*"));
         verify(statementMock, times(1)).executeLargeUpdate(matches("MERGE.*"));
         verify(statementMock, times(1)).executeLargeUpdate(matches("DELETE(.*)final.id = ingest.id"));
-        assertEquals(0, processor.buffer.size(), "Buffer should be empty after flush");
+        assertEquals(0, processor.buffer.size(), "Buffer map should be empty after flush");
         assertTrue(Files.isDirectory(Path.of("/mnt/data/csv_data_to_stage/test_stage")));
         assertTrue(Files.list(Path.of("/mnt/data/csv_data_to_stage/test_stage")).toList().isEmpty());
     }
@@ -260,8 +290,10 @@ class CdcDbzSchemaProcessorTest {
         processor.put(generateCreateEvents(dt, "1"));
         processor.put(generateDeleteEvents(dt, "2"));
         var blockID = "111";
+        var tableBuffer = processor.buffer.get("test_table");
         var csvBaos = processor.prepareOrderedColumnsBasedOnTargetTable(blockID,
-                List.of("id", "name", "timestamp", "time", "date", "desc", IHTOPIC, IHOFFSET, IHPARTITION, IHOP, IHBLOCKID, IHDATETIME));
+                List.of("id", "name", "timestamp", "time", "date", "desc", IHTOPIC, IHOFFSET, IHPARTITION, IHOP, IHBLOCKID, IHDATETIME),
+                tableBuffer);
         var pattern = Pattern.compile("""
                 "1","Name 1","2018-01-10T08:30:40","10:30:40","2018-01-09",,"test_topic","0","0","c","111",(?<msgtimestampc>.*)
                 "2","Name 2","2018-01-10T08:30:40","10:30:40","2018-01-09",,"test_topic","0","0","d","111",(?<msgtimestampd>.*)
@@ -277,7 +309,10 @@ class CdcDbzSchemaProcessorTest {
     @Test
     void testStartCleanUpJobSuccess() throws SchedulerException, SQLException {
         var processor = new CdcDbzSchemaProcessor();
+        var dt = LocalDateTime.of(2018, 1, 10, 10, 30, 40);
         var statement = prepareToFlush(processor);
+        // put() registers "test_table_INGEST" in knownIngestTables via getOrCreateBuffer
+        processor.put(generateCreateEvents(dt, "1"));
         var props = generateConfig().originals();
         props.put(SnowflakeSinkConnector.CFG_JOB_CLEANUP_DURATION, "PT1S");
         processor.startCleanUpJob(new AbstractConfig(SnowflakeSinkConnector.CONFIG_DEF, props));
@@ -290,7 +325,6 @@ class CdcDbzSchemaProcessorTest {
                 List.of("id", "name", "timestamp", "time", "date", "desc", "ih_topic", "ih_offset", "ih_partition", "ih_op", "ih_datetime", "ih_blockid"),
                 "test_table", "test_table_INGEST");
         processor.configParameters(generateConfig());
-        processor.configMetadata();
         return statementMock;
     }
 
@@ -359,12 +393,16 @@ class CdcDbzSchemaProcessorTest {
     }
 
     private Collection<SinkRecord> generateCreateEvents(LocalDateTime dt, String... ids) {
+        return generateCreateEventsForTopic(dt, "test_topic", ids);
+    }
+
+    private Collection<SinkRecord> generateCreateEventsForTopic(LocalDateTime dt, String topic, String... ids) {
         var records = new ArrayList<SinkRecord>();
 
         for (int i = 0; i < ids.length; i++) {
             var id = ids[i];
             records.add(new SinkRecord(
-                    "test_topic",
+                    topic,
                     0,
                     keySchema,
                     new Struct(keySchema).put("id", id),

--- a/src/test/java/br/com/datastreambrasil/v3/CleanupJobTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/CleanupJobTest.java
@@ -1,0 +1,98 @@
+package br.com.datastreambrasil.v3;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CleanupJobTest {
+
+    private JobExecutionContext contextWith(Object ingestTables, Connection connection) {
+        var context = mock(JobExecutionContext.class);
+        var jobDataMap = new JobDataMap();
+        if (ingestTables != null) {
+            jobDataMap.put(CleanupJob.INGEST_TABLE_NAMES, ingestTables);
+        }
+        if (connection != null) {
+            jobDataMap.put(CleanupJob.SNOWFLAKE_CONNECTION, connection);
+        }
+        when(context.getMergedJobDataMap()).thenReturn(jobDataMap);
+        return context;
+    }
+
+    @Test
+    void execute_withNullIngestTables_skipsCleanup() throws SQLException {
+        var connection = mock(Connection.class);
+        var context = contextWith(null, connection);
+
+        new CleanupJob().execute(context);
+
+        verify(connection, never()).createStatement();
+    }
+
+    @Test
+    void execute_withEmptyIngestTables_skipsCleanup() throws SQLException {
+        var connection = mock(Connection.class);
+        var context = contextWith(Set.of(), connection);
+
+        new CleanupJob().execute(context);
+
+        verify(connection, never()).createStatement();
+    }
+
+    @Test
+    void execute_withIngestTable_executesDeleteQuery() throws SQLException {
+        var connection = mock(Connection.class);
+        var stmt = mock(Statement.class);
+        when(connection.createStatement()).thenReturn(stmt);
+        var context = contextWith(Set.of("MY_TABLE_INGEST"), connection);
+
+        new CleanupJob().execute(context);
+
+        var captor = ArgumentCaptor.forClass(String.class);
+        verify(stmt, times(1)).executeLargeUpdate(captor.capture());
+        var sql = captor.getValue();
+        assertTrue(sql.contains("MY_TABLE_INGEST"), "DELETE must reference the ingest table name");
+        assertTrue(sql.toLowerCase().contains("delete"), "SQL must be a DELETE statement");
+        assertTrue(sql.contains("ih_datetime"), "DELETE must filter by ih_datetime");
+    }
+
+    @Test
+    void execute_withMultipleIngestTables_executesDeleteForEachTable() throws SQLException {
+        var connection = mock(Connection.class);
+        var stmt = mock(Statement.class);
+        when(connection.createStatement()).thenReturn(stmt);
+        var context = contextWith(Set.of("TABLE_A_INGEST", "TABLE_B_INGEST"), connection);
+
+        new CleanupJob().execute(context);
+
+        verify(connection, times(2)).createStatement();
+        verify(stmt, times(2)).executeLargeUpdate(any());
+    }
+
+    @Test
+    void execute_whenSqlExceptionThrown_logsErrorAndDoesNotRethrow() throws SQLException {
+        var connection = mock(Connection.class);
+        var stmt = mock(Statement.class);
+        when(connection.createStatement()).thenReturn(stmt);
+        when(stmt.executeLargeUpdate(any())).thenThrow(new SQLException("db error"));
+        var context = contextWith(Set.of("MY_TABLE_INGEST"), connection);
+
+        assertDoesNotThrow(() -> new CleanupJob().execute(context),
+                "SQLException must be caught internally and not propagate");
+    }
+}

--- a/src/test/java/br/com/datastreambrasil/v3/SnowflakeSinkConnectorTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/SnowflakeSinkConnectorTest.java
@@ -6,6 +6,8 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class SnowflakeSinkConnectorTest {
 
@@ -40,5 +42,21 @@ class SnowflakeSinkConnectorTest {
         assertFalse(taskConfigs.get(0).containsKey(SnowflakeSinkConnector.CFG_JOB_CLEANUP_DISABLE));
         assertEquals("true", taskConfigs.get(1).get(SnowflakeSinkConnector.CFG_JOB_CLEANUP_DISABLE));
         assertEquals("true", taskConfigs.get(2).get(SnowflakeSinkConnector.CFG_JOB_CLEANUP_DISABLE));
+    }
+
+    @Test
+    void version_returnsV3() {
+        assertEquals("v3", new SnowflakeSinkConnector().version());
+    }
+
+    @Test
+    void taskClass_returnsSnowflakeSinkTaskClass() {
+        assertSame(SnowflakeSinkTask.class, new SnowflakeSinkConnector().taskClass());
+    }
+
+    @Test
+    void config_returnsNonNullConfigDef() {
+        assertNotNull(new SnowflakeSinkConnector().config());
+        assertSame(SnowflakeSinkConnector.CONFIG_DEF, new SnowflakeSinkConnector().config());
     }
 }

--- a/src/test/java/br/com/datastreambrasil/v3/SnowflakeSinkTaskTest.java
+++ b/src/test/java/br/com/datastreambrasil/v3/SnowflakeSinkTaskTest.java
@@ -1,0 +1,78 @@
+package br.com.datastreambrasil.v3;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class SnowflakeSinkTaskTest {
+
+    private static AbstractProcessor injectMockProcessor(SnowflakeSinkTask task) throws Exception {
+        var mockProcessor = mock(AbstractProcessor.class);
+        Field field = SnowflakeSinkTask.class.getDeclaredField("processor");
+        field.setAccessible(true);
+        field.set(task, mockProcessor);
+        return mockProcessor;
+    }
+
+    @Test
+    void version_returnsConnectorVersion() {
+        assertEquals(SnowflakeSinkConnector.VERSION, new SnowflakeSinkTask().version());
+    }
+
+    @Test
+    void start_withUnknownProfile_throwsRuntimeException() {
+        var task = new SnowflakeSinkTask();
+        var ex = assertThrows(RuntimeException.class, () -> task.start(Map.of(
+                "schema", "test_schema",
+                "table", "test_table",
+                "stage", "test_stage",
+                "profile", "unknown_profile"
+        )));
+        assertTrue(ex.getMessage().contains("unknown_profile"),
+                "Exception message should name the unknown profile");
+    }
+
+    @Test
+    void put_delegatesToProcessor() throws Exception {
+        var task = new SnowflakeSinkTask();
+        var processor = injectMockProcessor(task);
+        Collection<SinkRecord> records = List.of(mock(SinkRecord.class));
+
+        task.put(records);
+
+        verify(processor).put(records);
+    }
+
+    @Test
+    void flush_delegatesToProcessor() throws Exception {
+        var task = new SnowflakeSinkTask();
+        var processor = injectMockProcessor(task);
+        var offsets = Map.<TopicPartition, OffsetAndMetadata>of();
+
+        task.flush(offsets);
+
+        verify(processor).flush(offsets);
+    }
+
+    @Test
+    void stop_delegatesToProcessor() throws Exception {
+        var task = new SnowflakeSinkTask();
+        var processor = injectMockProcessor(task);
+
+        task.stop();
+
+        verify(processor).stop();
+    }
+}


### PR DESCRIPTION
- Adiciona opção para processar múltiplas tabelas em um schema
- Adiciona opção de não executar show columns pegando os dados da view information_schema.columns
- Adiciona opção de enviar os nomes das colunas das tabelas para não consultar o Snowflake para v2 e v3
